### PR TITLE
Implement sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,7 @@ hs_err_pid*
 # IntelliJ files
 .idea
 *.iml
-
+# Eclipse
+.classpath
+.project
+.settings

--- a/src/main/java/dev/pgm/community/Community.java
+++ b/src/main/java/dev/pgm/community/Community.java
@@ -61,6 +61,7 @@ public class Community extends JavaPlugin {
 
   @Override
   public void onDisable() {
+    features.disable();
     if (database != null) {
       database.close();
     }

--- a/src/main/java/dev/pgm/community/CommunityPermissions.java
+++ b/src/main/java/dev/pgm/community/CommunityPermissions.java
@@ -32,6 +32,9 @@ public interface CommunityPermissions {
   String RELOAD = ROOT + ".reload";
   String RESTRICTED = ROOT + ".restricted"; // Access to restricted info (e.g IP addresses)
 
+  // Sessions
+  String FIND = ROOT + ".find"; // Access to the /find command
+
   // Teleports
   String TELEPORT = ROOT + ".teleport"; // Access to teleport to another player
   String TELEPORT_OTHERS = TELEPORT + ".others"; // Access to teleport other players

--- a/src/main/java/dev/pgm/community/assistance/services/SQLAssistanceService.java
+++ b/src/main/java/dev/pgm/community/assistance/services/SQLAssistanceService.java
@@ -17,7 +17,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import tc.oc.pgm.util.concurrent.ThreadSafeConnection.Query;
 
-public class SQLAssistanceService extends SQLFeatureBase<Report> {
+public class SQLAssistanceService extends SQLFeatureBase<Report, String> {
 
   private static final String TABLE_NAME = "reports";
   private static final String TABLE_FIELDS =

--- a/src/main/java/dev/pgm/community/database/Savable.java
+++ b/src/main/java/dev/pgm/community/database/Savable.java
@@ -3,11 +3,11 @@ package dev.pgm.community.database;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-public interface Savable<T> {
+public interface Savable<T, R> {
 
   void save(T t);
 
-  CompletableFuture<List<T>> queryList(String target);
+  CompletableFuture<List<T>> queryList(R target);
 
-  CompletableFuture<T> query(String target);
+  CompletableFuture<T> query(R target);
 }

--- a/src/main/java/dev/pgm/community/feature/FeatureManager.java
+++ b/src/main/java/dev/pgm/community/feature/FeatureManager.java
@@ -29,6 +29,8 @@ import dev.pgm.community.nick.feature.NickFeature;
 import dev.pgm.community.nick.feature.types.SQLNickFeature;
 import dev.pgm.community.requests.feature.RequestFeature;
 import dev.pgm.community.requests.feature.types.SQLRequestFeature;
+import dev.pgm.community.sessions.feature.SessionFeature;
+import dev.pgm.community.sessions.feature.types.SQLSessionFeature;
 import dev.pgm.community.teleports.TeleportFeature;
 import dev.pgm.community.teleports.TeleportFeatureBase;
 import dev.pgm.community.users.feature.UsersFeature;
@@ -52,6 +54,7 @@ public class FeatureManager {
   private final NetworkFeature network;
   private final NickFeature nick;
   private final RequestFeature requests;
+  private final SessionFeature sessions;
 
   private final TeleportFeature teleports;
   private final InfoCommandsFeature infoCommands;
@@ -74,6 +77,7 @@ public class FeatureManager {
 
     // DB Features
     this.users = new SQLUsersFeature(config, logger, database);
+    this.sessions = new SQLSessionFeature(users, logger, database);
     this.reports = new SQLAssistanceFeature(config, logger, database, users, network, inventory);
     this.moderation = new SQLModerationFeature(config, logger, database, users, network);
     this.friends = new SQLFriendshipFeature(config, logger, database, users);
@@ -109,6 +113,10 @@ public class FeatureManager {
 
   public UsersFeature getUsers() {
     return users;
+  }
+
+  public SessionFeature getSessions() {
+    return sessions;
   }
 
   public TeleportFeature getTeleports() {
@@ -165,6 +173,7 @@ public class FeatureManager {
     commands.registerDependency(UsersFeature.class, getUsers());
     commands.registerDependency(AssistanceFeature.class, getReports());
     commands.registerDependency(ModerationFeature.class, getModeration());
+    commands.registerDependency(SessionFeature.class, getSessions());
     commands.registerDependency(TeleportFeature.class, getTeleports());
     commands.registerDependency(ChatManagementFeature.class, getChatManagement());
     commands.registerDependency(FriendshipFeature.class, getFriendships());
@@ -213,6 +222,7 @@ public class FeatureManager {
     registerFeatureCommands(getUsers(), commands);
     registerFeatureCommands(getReports(), commands);
     registerFeatureCommands(getModeration(), commands);
+    registerFeatureCommands(getSessions(), commands);
     registerFeatureCommands(getTeleports(), commands);
     registerFeatureCommands(getChatManagement(), commands);
     registerFeatureCommands(getFriendships(), commands);
@@ -244,6 +254,7 @@ public class FeatureManager {
     getReports().getConfig().reload(config);
     getModeration().getConfig().reload(config);
     getUsers().getConfig().reload(config);
+    getSessions().getConfig().reload(config);
     getTeleports().getConfig().reload(config);
     getInfoCommands().getConfig().reload(config);
     getChatManagement().getConfig().reload(config);
@@ -258,5 +269,19 @@ public class FeatureManager {
     // TODO: Look into maybe unregister commands for features that have been disabled
     // commands#unregisterCommand
     // Will need to check isEnabled
+  }
+
+  public void disable() {
+    if (getReports().isEnabled()) getReports().disable();
+    if (getModeration().isEnabled()) getModeration().disable();
+    if (getUsers().isEnabled()) getUsers().disable();
+    if (getSessions().isEnabled()) getSessions().disable();
+    if (getTeleports().isEnabled()) getTeleports().disable();
+    if (getInfoCommands().isEnabled()) getInfoCommands().disable();
+    if (getChatManagement().isEnabled()) getChatManagement().disable();
+    if (getMotd().isEnabled()) getMotd().disable();
+    if (getFreeze().isEnabled()) getFreeze().disable();
+    if (getMutations().isEnabled()) getMutations().disable();
+    if (getBroadcast().isEnabled()) getBroadcast().disable();
   }
 }

--- a/src/main/java/dev/pgm/community/feature/SQLFeature.java
+++ b/src/main/java/dev/pgm/community/feature/SQLFeature.java
@@ -3,7 +3,7 @@ package dev.pgm.community.feature;
 import dev.pgm.community.database.DatabaseConnection;
 import dev.pgm.community.database.Savable;
 
-public interface SQLFeature<T> extends Savable<T> {
+public interface SQLFeature<T, R> extends Savable<T, R> {
 
   /** Create the SQL table for a data set */
   void createTable();

--- a/src/main/java/dev/pgm/community/feature/SQLFeatureBase.java
+++ b/src/main/java/dev/pgm/community/feature/SQLFeatureBase.java
@@ -6,7 +6,7 @@ import dev.pgm.community.database.query.TableQuery;
 import java.util.concurrent.CompletableFuture;
 
 /** Base implementation of {@link SQLFeature} * */
-public abstract class SQLFeatureBase<T> implements SQLFeature<T> {
+public abstract class SQLFeatureBase<T, R> implements SQLFeature<T, R> {
 
   private final String tableName;
   private final String fields;

--- a/src/main/java/dev/pgm/community/friends/Friendship.java
+++ b/src/main/java/dev/pgm/community/friends/Friendship.java
@@ -27,7 +27,7 @@ public class Friendship implements Comparable<Friendship> {
   }
 
   /**
-   * A friendship is a relation between to users
+   * A friendship is a relation between two users
    *
    * @param friendshipId - ID of friendship
    * @param requesterId - ID of player who requested

--- a/src/main/java/dev/pgm/community/friends/services/SQLFriendshipService.java
+++ b/src/main/java/dev/pgm/community/friends/services/SQLFriendshipService.java
@@ -19,7 +19,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import tc.oc.pgm.util.concurrent.ThreadSafeConnection.Query;
 
-public class SQLFriendshipService extends SQLFeatureBase<Friendship> {
+public class SQLFriendshipService extends SQLFeatureBase<Friendship, String> {
 
   private static final String TABLE_NAME = "friendships";
   private static final String TABLE_FIELDS =

--- a/src/main/java/dev/pgm/community/moderation/services/SQLModerationService.java
+++ b/src/main/java/dev/pgm/community/moderation/services/SQLModerationService.java
@@ -21,7 +21,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import tc.oc.pgm.util.concurrent.ThreadSafeConnection.Query;
 
-public class SQLModerationService extends SQLFeatureBase<Punishment> {
+public class SQLModerationService extends SQLFeatureBase<Punishment, String> {
 
   private static final String TABLE_NAME = "punishments";
   private static final String TABLE_FIELDS =

--- a/src/main/java/dev/pgm/community/nick/services/SQLNickService.java
+++ b/src/main/java/dev/pgm/community/nick/services/SQLNickService.java
@@ -18,7 +18,7 @@ import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nullable;
 import tc.oc.pgm.util.concurrent.ThreadSafeConnection.Query;
 
-public class SQLNickService extends SQLFeatureBase<Nick> {
+public class SQLNickService extends SQLFeatureBase<Nick, String> {
 
   private static final String TABLE_NAME = "nicknames";
   private static final String TABLE_FIELDS =

--- a/src/main/java/dev/pgm/community/requests/services/SQLRequestService.java
+++ b/src/main/java/dev/pgm/community/requests/services/SQLRequestService.java
@@ -17,7 +17,7 @@ import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nullable;
 import tc.oc.pgm.util.concurrent.ThreadSafeConnection.Query;
 
-public class SQLRequestService extends SQLFeatureBase<RequestProfile> {
+public class SQLRequestService extends SQLFeatureBase<RequestProfile, String> {
 
   private static final String TABLE_FIELDS =
       "(id VARCHAR(36) PRIMARY KEY, last_request_time LONG, last_request_map VARCHAR(255), last_sponsor_time LONG, last_sponsor_map VARCHAR(255), tokens INT, last_token_refresh LONG)";

--- a/src/main/java/dev/pgm/community/sessions/Session.java
+++ b/src/main/java/dev/pgm/community/sessions/Session.java
@@ -1,0 +1,83 @@
+package dev.pgm.community.sessions;
+
+import dev.pgm.community.Community;
+import java.time.Instant;
+import java.util.UUID;
+
+public class Session {
+
+  private final UUID sessionId; // ID of session
+
+  private final UUID playerId; // UUID of player
+  private final boolean disguised; // Whether the player is disguised/vanished
+
+  private final String serverName; // The server that this session was started on
+
+  private final Instant startDate; // Date the session started
+  private Instant endDate; // Date the session ended
+
+  public Session(UUID playerId, boolean disguised) {
+    this(
+        UUID.randomUUID(), playerId, disguised, Community.get().getServerId(), Instant.now(), null);
+  }
+
+  public Session(
+      UUID sessionId,
+      UUID playerId,
+      boolean disguised,
+      String serverName,
+      Instant startDate,
+      Instant endDate) {
+    this.sessionId = sessionId;
+    this.playerId = playerId;
+    this.disguised = disguised;
+    this.serverName = serverName;
+    this.startDate = startDate;
+    this.endDate = endDate;
+  }
+
+  public UUID getSessionId() {
+    return sessionId;
+  }
+
+  public UUID getPlayerId() {
+    return playerId;
+  }
+
+  public boolean isDisguised() {
+    return disguised;
+  }
+
+  public String getServerName() {
+    return serverName;
+  }
+
+  public Instant getStartDate() {
+    return startDate;
+  }
+
+  public Instant getEndDate() {
+    return endDate;
+  }
+
+  public void setEndDate(Instant endDate) {
+    this.endDate = endDate;
+  }
+
+  public boolean hasEnded() {
+    return getEndDate() != null;
+  }
+
+  /**
+   * Gets the most recent updated time for this session
+   *
+   * @return the end date if the session has ended, otherwise the start date.
+   */
+  public Instant getLatestUpdateDate() {
+    return hasEnded() ? getEndDate() : getStartDate();
+  }
+
+  public boolean isOnThisServer() {
+    return serverName.equals(Community.get().getServerConfig().getServerId());
+  }
+}

--- a/src/main/java/dev/pgm/community/sessions/SessionQuery.java
+++ b/src/main/java/dev/pgm/community/sessions/SessionQuery.java
@@ -1,0 +1,35 @@
+package dev.pgm.community.sessions;
+
+import java.util.UUID;
+
+public class SessionQuery {
+
+  private final UUID playerId; // the UUID of the player
+  private final boolean ignoreDisguised; // do we want to find a disguised session?
+
+  public SessionQuery(UUID playerId, boolean ignoreDisguised) {
+    this.playerId = playerId;
+    this.ignoreDisguised = ignoreDisguised;
+  }
+
+  public UUID getPlayerId() {
+    return playerId;
+  }
+
+  public boolean ignoreDisguised() {
+    return ignoreDisguised;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof SessionQuery)) return false;
+    SessionQuery other = (SessionQuery) obj;
+
+    return other.playerId.equals(playerId) && other.ignoreDisguised == ignoreDisguised;
+  }
+
+  @Override
+  public int hashCode() {
+    return playerId.hashCode() * 31 + (ignoreDisguised ? 1 : 0);
+  }
+}

--- a/src/main/java/dev/pgm/community/sessions/VanishedSessionListener.java
+++ b/src/main/java/dev/pgm/community/sessions/VanishedSessionListener.java
@@ -1,0 +1,30 @@
+package dev.pgm.community.sessions;
+
+import dev.pgm.community.sessions.feature.SessionFeature;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import tc.oc.pgm.api.event.PlayerVanishEvent;
+
+public class VanishedSessionListener implements Listener {
+
+  private final SessionFeature sessions;
+
+  public VanishedSessionListener(SessionFeature sessions) {
+    this.sessions = sessions;
+  }
+
+  @EventHandler
+  public void onVanish(PlayerVanishEvent event) {
+    Player player = event.getPlayer().getBukkit();
+    if (sessions.isPlayerJoining(player)) return;
+
+    sessions
+        .getLatestSession(player.getUniqueId(), false)
+        .thenAcceptAsync(
+            session -> {
+              sessions.endSession(session);
+              sessions.startSession(player);
+            });
+  }
+}

--- a/src/main/java/dev/pgm/community/sessions/feature/SessionFeature.java
+++ b/src/main/java/dev/pgm/community/sessions/feature/SessionFeature.java
@@ -1,0 +1,18 @@
+package dev.pgm.community.sessions.feature;
+
+import dev.pgm.community.feature.Feature;
+import dev.pgm.community.sessions.Session;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.bukkit.entity.Player;
+
+public interface SessionFeature extends Feature {
+
+  CompletableFuture<Session> getLatestSession(UUID playerId, boolean ignoreDisguised);
+
+  Session startSession(Player player);
+
+  void endSession(Session session);
+
+  boolean isPlayerJoining(Player player);
+}

--- a/src/main/java/dev/pgm/community/sessions/feature/SessionFeatureBase.java
+++ b/src/main/java/dev/pgm/community/sessions/feature/SessionFeatureBase.java
@@ -1,0 +1,75 @@
+package dev.pgm.community.sessions.feature;
+
+import com.google.common.collect.Sets;
+import dev.pgm.community.Community;
+import dev.pgm.community.CommunityCommand;
+import dev.pgm.community.feature.FeatureBase;
+import dev.pgm.community.sessions.VanishedSessionListener;
+import dev.pgm.community.users.feature.UsersFeature;
+import dev.pgm.community.utils.PGMUtils;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.logging.Logger;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+public abstract class SessionFeatureBase extends FeatureBase implements SessionFeature {
+
+  private List<UUID> joiningPlayers;
+  private VanishedSessionListener vanishedSessionListener;
+
+  public SessionFeatureBase(UsersFeature users, Logger logger, String featureName) {
+    super(users.getConfig(), logger, featureName);
+
+    if (getConfig().isEnabled()) {
+      this.joiningPlayers = new ArrayList<UUID>();
+      enable();
+
+      if (PGMUtils.isPGMEnabled()) {
+        vanishedSessionListener = new VanishedSessionListener(this);
+        Bukkit.getPluginManager().registerEvents(vanishedSessionListener, Community.get());
+      }
+    }
+  }
+
+  @Override
+  public void disable() {
+    if (vanishedSessionListener != null) HandlerList.unregisterAll(vanishedSessionListener);
+
+    for (Player player : Bukkit.getOnlinePlayers())
+      getLatestSession(player.getUniqueId(), false).thenAcceptAsync(this::endSession);
+  }
+
+  @Override
+  public Set<CommunityCommand> getCommands() {
+    return Sets.newHashSet();
+  }
+
+  @EventHandler(priority = EventPriority.LOWEST)
+  public void onJoinLowest(PlayerJoinEvent event) {
+    joiningPlayers.add(event.getPlayer().getUniqueId());
+  }
+
+  @EventHandler(priority = EventPriority.HIGHEST)
+  public void onJoinHighest(PlayerJoinEvent event) {
+    startSession(event.getPlayer());
+    joiningPlayers.remove(event.getPlayer().getUniqueId());
+  }
+
+  @EventHandler(priority = EventPriority.HIGHEST)
+  public void onQuitHighest(PlayerQuitEvent event) {
+    getLatestSession(event.getPlayer().getUniqueId(), false).thenAcceptAsync(this::endSession);
+  }
+
+  @Override
+  public boolean isPlayerJoining(Player player) {
+    return joiningPlayers.contains(player.getUniqueId());
+  }
+}

--- a/src/main/java/dev/pgm/community/sessions/feature/types/SQLSessionFeature.java
+++ b/src/main/java/dev/pgm/community/sessions/feature/types/SQLSessionFeature.java
@@ -1,0 +1,43 @@
+package dev.pgm.community.sessions.feature.types;
+
+import dev.pgm.community.database.DatabaseConnection;
+import dev.pgm.community.sessions.Session;
+import dev.pgm.community.sessions.SessionQuery;
+import dev.pgm.community.sessions.feature.SessionFeatureBase;
+import dev.pgm.community.sessions.services.SQLSessionService;
+import dev.pgm.community.users.feature.UsersFeature;
+import dev.pgm.community.utils.VisibilityUtils;
+import java.time.Instant;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.logging.Logger;
+import org.bukkit.entity.Player;
+
+public class SQLSessionFeature extends SessionFeatureBase {
+
+  private final SQLSessionService service;
+
+  public SQLSessionFeature(UsersFeature users, Logger logger, DatabaseConnection connection) {
+    super(users, logger, "Sessions (SQL)");
+    this.service = new SQLSessionService(connection);
+  }
+
+  @Override
+  public CompletableFuture<Session> getLatestSession(UUID playerId, boolean ignoreDisguised) {
+    return service.query(new SessionQuery(playerId, ignoreDisguised));
+  }
+
+  @Override
+  public Session startSession(Player player) {
+    Session session = new Session(player.getUniqueId(), VisibilityUtils.isDisguised(player));
+    service.save(session);
+
+    return session;
+  }
+
+  @Override
+  public void endSession(Session session) {
+    session.setEndDate(Instant.now());
+    service.updateSessionEndTime(session);
+  }
+}

--- a/src/main/java/dev/pgm/community/sessions/services/SQLSessionService.java
+++ b/src/main/java/dev/pgm/community/sessions/services/SQLSessionService.java
@@ -1,0 +1,206 @@
+package dev.pgm.community.sessions.services;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import dev.pgm.community.database.DatabaseConnection;
+import dev.pgm.community.feature.SQLFeatureBase;
+import dev.pgm.community.sessions.Session;
+import dev.pgm.community.sessions.SessionQuery;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nonnull;
+import tc.oc.pgm.util.concurrent.ThreadSafeConnection.Query;
+
+public class SQLSessionService extends SQLFeatureBase<Session, SessionQuery> {
+
+  private static final String TABLE_NAME = "sessions";
+  private static final String TABLE_FIELDS =
+      "(id VARCHAR(36) PRIMARY KEY, player VARCHAR(36), disguised BOOL, server VARCHAR(32), start_time BIGINT, end_time BIGINT)";
+
+  private final LoadingCache<SessionQuery, SelectLatestSessionQuery> sessionCache;
+
+  public SQLSessionService(DatabaseConnection database) {
+    super(database, TABLE_NAME, TABLE_FIELDS);
+    this.sessionCache =
+        CacheBuilder.newBuilder()
+            .build(
+                new CacheLoader<SessionQuery, SelectLatestSessionQuery>() {
+                  @Override
+                  public SelectLatestSessionQuery load(@Nonnull SessionQuery key) {
+                    return new SelectLatestSessionQuery(key.getPlayerId(), key.ignoreDisguised());
+                  }
+                });
+  }
+
+  @Override
+  public void save(Session session) {
+    SelectLatestSessionQuery query =
+        sessionCache.getUnchecked(new SessionQuery(session.getPlayerId(), false));
+    query.setSession(session);
+
+    query = sessionCache.getUnchecked(new SessionQuery(session.getPlayerId(), true));
+    query.invalidate();
+
+    getDatabase().submitQuery(new InsertQuery(session));
+  }
+
+  public void updateSessionEndTime(Session session) {
+    getDatabase().submitQuery(new UpdateSessionEndTimeQuery(session));
+  }
+
+  @Override
+  public CompletableFuture<List<Session>> queryList(SessionQuery target) {
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
+  public CompletableFuture<Session> query(SessionQuery target) {
+    SelectLatestSessionQuery query = sessionCache.getUnchecked(target);
+
+    if (query.hasFetched()) {
+      return CompletableFuture.completedFuture(query.getSession());
+    } else {
+      return getDatabase()
+          .submitQueryComplete(query)
+          .thenApplyAsync(q -> SelectLatestSessionQuery.class.cast(q).getSession());
+    }
+  }
+
+  private class InsertQuery implements Query {
+
+    private static final String INSERT_SESSION_QUERY =
+        "INSERT INTO "
+            + TABLE_NAME
+            + "(id, player, disguised, server, start_time, end_time) VALUES (?, ?, ?, ?, ?, ?)";
+
+    private final Session session;
+
+    public InsertQuery(Session session) {
+      this.session = session;
+    }
+
+    @Override
+    public String getFormat() {
+      return INSERT_SESSION_QUERY;
+    }
+
+    @Override
+    public void query(PreparedStatement statement) throws SQLException {
+      statement.setString(1, session.getSessionId().toString());
+      statement.setString(2, session.getPlayerId().toString());
+      statement.setBoolean(3, session.isDisguised());
+      statement.setString(4, session.getServerName());
+      statement.setLong(5, session.getStartDate().toEpochMilli());
+      statement.setObject(
+          6, session.getEndDate() == null ? null : session.getEndDate().toEpochMilli());
+      statement.executeUpdate();
+    }
+  }
+
+  private class SelectLatestSessionQuery implements Query {
+
+    private static final String SELECT_DISGUISED_QUERY =
+        "SELECT * from "
+            + TABLE_NAME
+            + " where player = ? AND disguised = 0 ORDER BY -end_time LIMIT 1";
+    private static final String SELECT_QUERY =
+        "SELECT * from " + TABLE_NAME + " where player = ? ORDER BY -end_time LIMIT 1";
+
+    private final UUID target;
+    private final boolean ignoreDisguised;
+
+    private Session session;
+    private boolean fetched;
+
+    public SelectLatestSessionQuery(UUID target, boolean ignoreDisguised) {
+      this.target = target;
+      this.ignoreDisguised = ignoreDisguised;
+    }
+
+    public Session getSession() {
+      return session;
+    }
+
+    public boolean hasFetched() {
+      return fetched;
+    }
+
+    @Override
+    public String getFormat() {
+      return ignoreDisguised ? SELECT_DISGUISED_QUERY : SELECT_QUERY;
+    }
+
+    @Override
+    public void query(PreparedStatement statement) throws SQLException {
+      if (fetched) return;
+
+      statement.setString(1, target.toString());
+
+      try (final ResultSet result = statement.executeQuery()) {
+        if (result.next()) {
+          String id = result.getString("id");
+
+          String player = result.getString("player");
+          boolean disguised = result.getBoolean("disguised");
+
+          String server = result.getString("server");
+
+          long startTime = result.getLong("start_time");
+          Object endTime = result.getObject("end_time");
+
+          session =
+              new Session(
+                  UUID.fromString(id),
+                  UUID.fromString(player),
+                  disguised,
+                  server,
+                  Instant.ofEpochMilli(startTime),
+                  endTime == null ? null : Instant.ofEpochMilli((Long) endTime));
+        }
+      }
+
+      fetched = true;
+    }
+
+    public void invalidate() {
+      fetched = false;
+      session = null;
+    }
+
+    public void setSession(Session session) {
+      fetched = true;
+      this.session = session;
+    }
+  }
+
+  private class UpdateSessionEndTimeQuery implements Query {
+
+    private static final String UPDATE_QUERY =
+        "UPDATE " + TABLE_NAME + " SET end_time = ? WHERE id = ?";
+
+    private final Session session;
+
+    public UpdateSessionEndTimeQuery(Session session) {
+      this.session = session;
+    }
+
+    @Override
+    public String getFormat() {
+      return UPDATE_QUERY;
+    }
+
+    @Override
+    public void query(PreparedStatement statement) throws SQLException {
+      statement.setObject(
+          1, session.getEndDate() == null ? null : session.getEndDate().toEpochMilli());
+      statement.setString(2, session.getSessionId().toString());
+      statement.executeUpdate();
+    }
+  }
+}

--- a/src/main/java/dev/pgm/community/users/UserProfile.java
+++ b/src/main/java/dev/pgm/community/users/UserProfile.java
@@ -1,7 +1,9 @@
 package dev.pgm.community.users;
 
+import dev.pgm.community.sessions.Session;
 import java.time.Instant;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * UserProfile
@@ -33,11 +35,11 @@ public interface UserProfile {
   Instant getFirstLogin();
 
   /**
-   * Get the player's last login date Note: last login is updated at server login & logout
+   * Get the player's session
    *
-   * @return Date of last login
+   * @return The player's session
    */
-  Instant getLastLogin();
+  CompletableFuture<Session> getLatestSession(boolean ignoreDisguisedSessions);
 
   /**
    * Get the player's number of server joins
@@ -45,13 +47,6 @@ public interface UserProfile {
    * @return Player join count
    */
   int getJoinCount();
-
-  /**
-   * Get the name of the last known server
-   *
-   * @return Name of the last known server
-   */
-  String getServerName();
 
   /**
    * Set the player's username
@@ -67,13 +62,6 @@ public interface UserProfile {
    * @param now The time of login
    */
   void setFirstLogin(Instant now);
-
-  /**
-   * Sets the player's last login date
-   *
-   * @param now The time of login
-   */
-  void setLastLogin(Instant now);
 
   /** Increases the join count by 1 */
   void incJoinCount();

--- a/src/main/java/dev/pgm/community/users/UserProfileImpl.java
+++ b/src/main/java/dev/pgm/community/users/UserProfileImpl.java
@@ -1,41 +1,28 @@
 package dev.pgm.community.users;
 
 import dev.pgm.community.Community;
+import dev.pgm.community.sessions.Session;
+import dev.pgm.community.sessions.feature.SessionFeature;
 import java.time.Instant;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 public class UserProfileImpl implements UserProfile {
 
   private UUID playerId;
   private String username;
   private Instant firstLogin;
-  private Instant lastLogin;
   private int joinCount;
-  private String serverName;
 
   public UserProfileImpl(UUID playerId, String username) {
-    this(
-        playerId,
-        username,
-        Instant.now(),
-        Instant.now(),
-        1,
-        Community.get().getServerConfig().getServerId());
+    this(playerId, username, Instant.now(), 1);
   }
 
-  public UserProfileImpl(
-      UUID playerId,
-      String username,
-      Instant firstLogin,
-      Instant lastLogin,
-      int joinCount,
-      String server) {
+  public UserProfileImpl(UUID playerId, String username, Instant firstLogin, int joinCount) {
     this.playerId = playerId;
     this.username = username;
     this.firstLogin = firstLogin;
-    this.lastLogin = lastLogin;
     this.joinCount = joinCount;
-    this.serverName = server;
   }
 
   @Override
@@ -54,18 +41,16 @@ public class UserProfileImpl implements UserProfile {
   }
 
   @Override
-  public Instant getLastLogin() {
-    return lastLogin;
+  public CompletableFuture<Session> getLatestSession(boolean ignoreDisguisedSessions) {
+    SessionFeature sessions = Community.get().getFeatures().getSessions();
+    if (!sessions.isEnabled()) return CompletableFuture.completedFuture(null);
+
+    return sessions.getLatestSession(getId(), ignoreDisguisedSessions);
   }
 
   @Override
   public int getJoinCount() {
     return joinCount;
-  }
-
-  @Override
-  public String getServerName() {
-    return serverName;
   }
 
   @Override
@@ -76,11 +61,6 @@ public class UserProfileImpl implements UserProfile {
   @Override
   public void setFirstLogin(Instant now) {
     this.firstLogin = now;
-  }
-
-  @Override
-  public void setLastLogin(Instant now) {
-    this.lastLogin = now;
   }
 
   @Override

--- a/src/main/java/dev/pgm/community/users/UserProfileWithSessionCallback.java
+++ b/src/main/java/dev/pgm/community/users/UserProfileWithSessionCallback.java
@@ -1,0 +1,8 @@
+package dev.pgm.community.users;
+
+import dev.pgm.community.sessions.Session;
+
+public interface UserProfileWithSessionCallback {
+
+  public void run(UserProfile profile, Session session);
+}

--- a/src/main/java/dev/pgm/community/users/feature/UsersFeature.java
+++ b/src/main/java/dev/pgm/community/users/feature/UsersFeature.java
@@ -2,10 +2,12 @@ package dev.pgm.community.users.feature;
 
 import dev.pgm.community.feature.Feature;
 import dev.pgm.community.users.UserProfile;
+import dev.pgm.community.users.UserProfileWithSessionCallback;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import net.kyori.adventure.text.Component;
@@ -139,4 +141,46 @@ public interface UsersFeature extends Feature {
   void onLogout(PlayerQuitEvent event);
 
   void saveImportedUser(UUID id, String name);
+
+  /**
+   * Queries the database for a user profile by either username or UUID and gets its latest session
+   *
+   * @param target Player username
+   * @param ignoreDisguised Whether the target's latest session should include disguised sessions
+   * @param callback The callback to be ran with
+   * @throws ExecutionException
+   */
+  default void findUserWithSession(
+      String target, boolean ignoreDisguised, UserProfileWithSessionCallback callback) {
+    CompletableFuture<UserProfile> profileFuture = getStoredProfile(target);
+    profileFuture.thenAcceptBothAsync(
+        profileFuture.thenApplyAsync(
+            profile -> {
+              if (profile == null) return null;
+
+              return profile.getLatestSession(ignoreDisguised).join();
+            }),
+        (profile, session) -> callback.run(profile, session));
+  }
+
+  /**
+   * Queries the database for a user profile by either username or UUID and gets its latest session
+   *
+   * @param id Player UUID
+   * @param ignoreDisguised Whether the target's latest session should include disguised sessions
+   * @param callback The callback to be ran with
+   * @throws ExecutionException
+   */
+  default void findUserWithSession(
+      UUID id, boolean ignoreDisguised, UserProfileWithSessionCallback callback) {
+    CompletableFuture<UserProfile> profileFuture = getStoredProfile(id);
+    profileFuture.thenAcceptBothAsync(
+        profileFuture.thenApplyAsync(
+            profile -> {
+              if (profile == null) return null;
+
+              return profile.getLatestSession(ignoreDisguised).join();
+            }),
+        (profile, session) -> callback.run(profile, session));
+  }
 }


### PR DESCRIPTION
- Adds an alias for `/seen` (`/find`) and changes the permission to `community.find`.
- Removes `last_join` and `server` fields in `users` table
- Allows for cross-server lookups for `/find`, `/profile` and `/friends`
  - Uses the latest undisguised session for players who aren't staff