### PR TITLE
Resolve UUIDs when a player has no punishments

### DIFF
--- a/src/main/java/dev/pgm/community/moderation/commands/PunishmentCommand.java
+++ b/src/main/java/dev/pgm/community/moderation/commands/PunishmentCommand.java
@@ -36,6 +36,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.TranslatableComponent;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.entity.Player;
@@ -292,12 +293,20 @@ public class PunishmentCommand extends CommunityCommand {
 
       @Override
       public Component formatEmpty() {
-        return target != null
-            ? translatable(
-                "moderation.records.lookupNone",
-                NamedTextColor.RED,
-                text(target, NamedTextColor.AQUA))
-            : text("There have been no recent punishments", NamedTextColor.RED);
+        if (target != null) {
+          TranslatableComponent noneFound =
+              translatable("moderation.records.lookupNone", NamedTextColor.RED);
+          try {
+            UUID uuid = UUID.fromString(target);
+            Component targetName =
+                usernames.renderUsername(uuid, NameStyle.PLAIN).join().color(NamedTextColor.AQUA);
+            return noneFound.args(targetName);
+          } catch (IllegalArgumentException e) {
+            // No-op
+          }
+          return noneFound.args(text(target, NamedTextColor.AQUA));
+        }
+        return text("There have been no recent punishments", NamedTextColor.RED);
       }
     }.display(
         audience.getAudience(),


### PR DESCRIPTION
Before:
`/l` with a UUID
<img width="623" alt="Skjermbilde 2022-01-15 kl  22 55 22" src="https://user-images.githubusercontent.com/19822231/149638952-b9e2ac14-da14-41d4-8971-53e9c82a243e.png">

`/l` through the click event for offline players in `/alts`
<img width="689" alt="Skjermbilde 2022-01-15 kl  22 55 33" src="https://user-images.githubusercontent.com/19822231/149638953-fbe82b18-ed4e-4aca-a98c-939a0cee2d12.png">

After:
`/l` with a UUID
<img width="532" alt="Skjermbilde 2022-01-15 kl  22 46 17" src="https://user-images.githubusercontent.com/19822231/149638950-b9a90c87-0cc6-4e7a-bd03-b85f49223f17.png">

`/l` through the click event for offline players in `/alts`
<img width="644" alt="Skjermbilde 2022-01-15 kl  22 51 29" src="https://user-images.githubusercontent.com/19822231/149638951-1cfda0e9-06dd-46be-acfb-78e84a95993d.png">

