### PR TITLE
Add old "frs" alias to Friendship command

### DIFF
--- a/src/main/java/dev/pgm/community/friends/commands/FriendshipCommand.java
+++ b/src/main/java/dev/pgm/community/friends/commands/FriendshipCommand.java
@@ -52,7 +52,7 @@ import tc.oc.pgm.util.named.NameStyle;
 import tc.oc.pgm.util.player.PlayerComponent;
 import tc.oc.pgm.util.text.TextFormatter;
 
-@CommandAlias("friend|friendship|fs")
+@CommandAlias("friend|friendship|fs|frs")
 @Description("Manage your friend relationships")
 @CommandPermission(CommunityPermissions.FRIENDSHIP)
 public class FriendshipCommand extends CommunityCommand {


### PR DESCRIPTION
You were able to use `/frs` on the Overcast Network to list your friends (like you can now do by default with `/friend` `/friends` `/friendship` `/fs`). Didn't think it'd hurt to have it back!