### PR TITLE
Add Cannon Supplies mutation

### DIFF
--- a/src/main/java/dev/pgm/community/mutations/MutationType.java
+++ b/src/main/java/dev/pgm/community/mutations/MutationType.java
@@ -28,7 +28,8 @@ public enum MutationType {
   WEB_SLINGERS("Web Slingers", "Shoot webs like a spider", Material.WEB),
   MOBS("Mob", "Attack of the mobs", Material.MOB_SPAWNER),
   TNT_BOW("TNT Bow", "All projectiles are TNT", Material.TNT),
-  FIREBALL_BOW("Fireball Bow", "All projectiles are fireballs", Material.FIREBALL);
+  FIREBALL_BOW("Fireball Bow", "All projectiles are fireballs", Material.FIREBALL),
+  CANNON_SUPPLIES("Cannon Supplies", "Supplies for making TNT cannons", Material.REDSTONE);
 
   String displayName;
   String description;

--- a/src/main/java/dev/pgm/community/mutations/feature/MutationFeature.java
+++ b/src/main/java/dev/pgm/community/mutations/feature/MutationFeature.java
@@ -21,6 +21,7 @@ import dev.pgm.community.mutations.types.gameplay.BlitzMutation;
 import dev.pgm.community.mutations.types.gameplay.GhostMutation;
 import dev.pgm.community.mutations.types.gameplay.RageMutation;
 import dev.pgm.community.mutations.types.items.BreadMutation;
+import dev.pgm.community.mutations.types.items.CannonSuppliesMutation;
 import dev.pgm.community.mutations.types.items.ExplosionMutation;
 import dev.pgm.community.mutations.types.items.FireworkMutation;
 import dev.pgm.community.mutations.types.items.PotionMutation;
@@ -197,6 +198,8 @@ public class MutationFeature extends FeatureBase {
         return new TNTBowMutation(getMatch());
       case FIREBALL_BOW:
         return new FireballBowMutation(getMatch());
+      case CANNON_SUPPLIES:
+        return new CannonSuppliesMutation(getMatch());
       default:
         logger.warning(type.getDisplayName() + " has not been implemented yet");
     }

--- a/src/main/java/dev/pgm/community/mutations/types/KitMutationBase.java
+++ b/src/main/java/dev/pgm/community/mutations/types/KitMutationBase.java
@@ -4,12 +4,14 @@ import com.google.common.collect.Lists;
 import dev.pgm.community.mutations.MutationBase;
 import dev.pgm.community.mutations.MutationType;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.inventory.ItemStack;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.kits.Kit;
+import tc.oc.pgm.kits.tag.ItemTags;
 import tc.oc.pgm.spawns.events.ParticipantKitApplyEvent;
 
 /** KitMutation - A base for mutations which grant kits * */
@@ -20,6 +22,15 @@ public abstract class KitMutationBase extends MutationBase {
   public KitMutationBase(Match match, MutationType type, Kit... kits) {
     super(match, type);
     this.kits = Lists.newArrayList(kits);
+  }
+
+  protected static ItemStack preventSharing(ItemStack itemStack) {
+    ItemTags.PREVENT_SHARING.set(itemStack, true);
+    return itemStack;
+  }
+
+  protected static List<ItemStack> preventSharing(List<ItemStack> itemStack) {
+    return itemStack.stream().map(KitMutationBase::preventSharing).collect(Collectors.toList());
   }
 
   @Override

--- a/src/main/java/dev/pgm/community/mutations/types/items/BreadMutation.java
+++ b/src/main/java/dev/pgm/community/mutations/types/items/BreadMutation.java
@@ -41,7 +41,6 @@ import tc.oc.pgm.events.PlayerJoinMatchEvent;
 import tc.oc.pgm.events.PlayerPartyChangeEvent;
 import tc.oc.pgm.kits.ItemKit;
 import tc.oc.pgm.kits.Kit;
-import tc.oc.pgm.kits.tag.ItemTags;
 import tc.oc.pgm.loot.WeightedRandomChooser;
 import tc.oc.pgm.match.ObserverParty;
 import tc.oc.pgm.util.block.BlockVectors;
@@ -99,11 +98,6 @@ public class BreadMutation extends KitMutationBase {
     potionChooser = new WeightedRandomChooser<>();
     potionChooser.addAll(BAD_POTION_MAP);
     badBreadSet = new HashSet<>();
-  }
-
-  static ItemStack preventSharing(ItemStack itemStack) {
-    ItemTags.PREVENT_SHARING.set(itemStack, true);
-    return itemStack;
   }
 
   static ImmutableMap<ItemStack, Double> getBreadsMap() {

--- a/src/main/java/dev/pgm/community/mutations/types/items/CannonSuppliesMutation.java
+++ b/src/main/java/dev/pgm/community/mutations/types/items/CannonSuppliesMutation.java
@@ -1,0 +1,81 @@
+package dev.pgm.community.mutations.types.items;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import dev.pgm.community.mutations.Mutation;
+import dev.pgm.community.mutations.MutationType;
+import dev.pgm.community.mutations.types.KitMutationBase;
+import java.util.List;
+import java.util.Set;
+import org.bukkit.Material;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.inventory.ItemStack;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.api.player.ParticipantState;
+import tc.oc.pgm.api.player.event.MatchPlayerDeathEvent;
+import tc.oc.pgm.kits.ItemKit;
+import tc.oc.pgm.kits.Kit;
+import tc.oc.pgm.tnt.TNTMatchModule;
+
+public class CannonSuppliesMutation extends KitMutationBase {
+  public CannonSuppliesMutation(Match match) {
+    super(match, MutationType.CANNON_SUPPLIES);
+  }
+
+  // Order is to allow partial kits to build functional cannons. The more items the player receives
+  // the more complicated the cannons they can build
+  static List<Kit> spawnKit =
+      Lists.newArrayList(
+          new ItemKit(
+              Maps.newHashMap(),
+              preventSharing(
+                  Lists.newArrayList(
+                      new ItemStack(Material.TNT, 64),
+                      new ItemStack(Material.WATER_BUCKET),
+                      new ItemStack(Material.STONE_BUTTON, 32),
+                      new ItemStack(Material.LADDER, 32),
+                      new ItemStack(Material.TNT, 64),
+                      new ItemStack(Material.REDSTONE, 64),
+                      new ItemStack(Material.WATER_BUCKET),
+                      new ItemStack(Material.FENCE, 32),
+                      new ItemStack(Material.WOOD_STEP, 64),
+                      new ItemStack(Material.TNT, 64),
+                      new ItemStack(Material.WOOD, 64),
+                      new ItemStack(Material.TNT, 64),
+                      new ItemStack(Material.DIODE, 64)))));
+
+  static ItemKit killRewardKit =
+      new ItemKit(
+          Maps.newHashMap(), Lists.newArrayList(preventSharing(new ItemStack(Material.TNT, 16))));
+
+  @Override
+  public List<Kit> getKits() {
+    return spawnKit;
+  }
+
+  @Override
+  public boolean canEnable(Set<Mutation> existingMutations) {
+    TNTMatchModule tntMatchModule = match.getModule(TNTMatchModule.class);
+    if (tntMatchModule == null) return true;
+
+    return !tntMatchModule.getProperties().instantIgnite;
+  }
+
+  @Override
+  protected void givePlayerKit(MatchPlayer player, List<Kit> kits) {
+    kits.forEach(kit -> player.applyKit(kit, false));
+  }
+
+  @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+  public void onDeath(MatchPlayerDeathEvent event) {
+    ParticipantState killer = event.getKiller();
+    if (event.isChallengeKill() && killer != null) {
+      MatchPlayer player = match.getPlayer(killer.getId());
+      if (player != null && player.isAlive()) {
+        player.applyKit(killRewardKit, false);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds a mutation that gives TNT cannon making supplies to players.

The item order is to allow partial kits to build functional cannons. The more items the player receives the more complicated the cannons they can build.

Mutation cannot be set when tnt auto-ignite is enabled.

_This should actually be formatted this time._