### PR TITLE
Add Grappling Hook mutation

### DIFF
--- a/src/main/java/dev/pgm/community/mutations/MutationType.java
+++ b/src/main/java/dev/pgm/community/mutations/MutationType.java
@@ -29,7 +29,8 @@ public enum MutationType {
   MOBS("Mob", "Attack of the mobs", Material.MOB_SPAWNER),
   TNT_BOW("TNT Bow", "All projectiles are TNT", Material.TNT),
   FIREBALL_BOW("Fireball Bow", "All projectiles are fireballs", Material.FIREBALL),
-  CANNON_SUPPLIES("Cannon Supplies", "Supplies for making TNT cannons", Material.REDSTONE);
+  CANNON_SUPPLIES("Cannon Supplies", "Supplies for making TNT cannons", Material.REDSTONE),
+  GRAPPLING_HOOK("Grappling Hook", "Everyone can use a grappling hook", Material.FISHING_ROD);
 
   String displayName;
   String description;

--- a/src/main/java/dev/pgm/community/mutations/feature/MutationFeature.java
+++ b/src/main/java/dev/pgm/community/mutations/feature/MutationFeature.java
@@ -24,6 +24,7 @@ import dev.pgm.community.mutations.types.items.BreadMutation;
 import dev.pgm.community.mutations.types.items.CannonSuppliesMutation;
 import dev.pgm.community.mutations.types.items.ExplosionMutation;
 import dev.pgm.community.mutations.types.items.FireworkMutation;
+import dev.pgm.community.mutations.types.items.GrapplingHookMutation;
 import dev.pgm.community.mutations.types.items.PotionMutation;
 import dev.pgm.community.mutations.types.mechanics.BlindMutation;
 import dev.pgm.community.mutations.types.mechanics.DoubleJumpMutation;
@@ -200,6 +201,8 @@ public class MutationFeature extends FeatureBase {
         return new FireballBowMutation(getMatch());
       case CANNON_SUPPLIES:
         return new CannonSuppliesMutation(getMatch());
+      case GRAPPLING_HOOK:
+        return new GrapplingHookMutation(getMatch());
       default:
         logger.warning(type.getDisplayName() + " has not been implemented yet");
     }

--- a/src/main/java/dev/pgm/community/mutations/types/items/GrapplingHookMutation.java
+++ b/src/main/java/dev/pgm/community/mutations/types/items/GrapplingHookMutation.java
@@ -1,0 +1,112 @@
+package dev.pgm.community.mutations.types.items;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import dev.pgm.community.Community;
+import dev.pgm.community.mutations.Mutation;
+import dev.pgm.community.mutations.MutationType;
+import dev.pgm.community.mutations.types.KitMutationBase;
+import java.util.List;
+import java.util.Set;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.entity.FishHook;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.player.PlayerFishEvent;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.metadata.FixedMetadataValue;
+import org.bukkit.util.Vector;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.kits.ItemKit;
+import tc.oc.pgm.kits.Kit;
+import tc.oc.pgm.kits.tag.ItemTags;
+import tc.oc.pgm.util.bukkit.OnlinePlayerMapAdapter;
+import tc.oc.pgm.util.inventory.ItemBuilder;
+import tc.oc.pgm.util.inventory.tag.ItemTag;
+
+public class GrapplingHookMutation extends KitMutationBase {
+
+  private final OnlinePlayerMapAdapter<Long> playerCooldowns;
+
+  private static final int COOLDOWN_MILISECONDS = 2000;
+  public final String GRAPPLE_META = "grappling-hook";
+  public final ItemTag<Boolean> GRAPPLE_META_TAG = ItemTag.newBoolean(GRAPPLE_META);
+
+  public GrapplingHookMutation(Match match) {
+    super(match, MutationType.GRAPPLING_HOOK);
+    playerCooldowns = new OnlinePlayerMapAdapter<>(Community.get());
+  }
+
+  @Override
+  public boolean canEnable(Set<Mutation> existingMutations) {
+    return true;
+  }
+
+  @Override
+  public List<Kit> getKits() {
+    return Lists.newArrayList(new ItemKit(Maps.newHashMap(), Lists.newArrayList(getGrappleHook())));
+  }
+
+  public ItemStack getGrappleHook() {
+    ItemStack grapple =
+        new ItemBuilder()
+            .material(Material.FISHING_ROD)
+            .name(ChatColor.GREEN + "Grappling Hook")
+            .lore(ChatColor.GRAY + "Launch, anchor, conquer!")
+            .flags(ItemFlag.values())
+            .unbreakable(true)
+            .build();
+
+    ItemTags.PREVENT_SHARING.set(grapple, true);
+    GRAPPLE_META_TAG.set(grapple, true);
+
+    return grapple;
+  }
+
+  @EventHandler(ignoreCancelled = true)
+  public void onPlayerFishEvent(PlayerFishEvent event) {
+    if (!GRAPPLE_META_TAG.has(event.getPlayer().getItemInHand())) return;
+
+    // Set the hooks meta if the player has thrown the line
+    if (event.getState() == PlayerFishEvent.State.FISHING) {
+      event.getHook().setMetadata(GRAPPLE_META, new FixedMetadataValue(Community.get(), true));
+    }
+
+    // Only pull the player when reeling back in
+    if (!(event.getState() == PlayerFishEvent.State.IN_GROUND
+        || event.getState() == PlayerFishEvent.State.FAILED_ATTEMPT)) return;
+
+    if (isPlayerOnCooldown(event.getPlayer())) return;
+
+    // Calculate velocity to apply to player
+    Location hookLocation = event.getHook().getLocation();
+    Location playerLocation = event.getPlayer().getLocation();
+    Vector direction = hookLocation.toVector().subtract(playerLocation.toVector());
+    direction.multiply(0.5).setY(1);
+
+    event.getPlayer().setVelocity(direction);
+    event.getPlayer().playSound(playerLocation, Sound.BAT_TAKEOFF, 2, 1.2f);
+
+    playerCooldowns.put(event.getPlayer(), System.currentTimeMillis());
+  }
+
+  @EventHandler(ignoreCancelled = true)
+  public void onDamage(EntityDamageByEntityEvent event) {
+    if (!(event.getDamager() instanceof FishHook)) return;
+    FishHook fishHook = (FishHook) event.getDamager();
+    if (!(fishHook.getShooter() instanceof Player)) return;
+
+    // Cancel damage if caused by a grappling hook
+    if (fishHook.hasMetadata(GRAPPLE_META)) event.setCancelled(true);
+  }
+
+  private boolean isPlayerOnCooldown(Player player) {
+    Long lastGrapple = playerCooldowns.get(player);
+    return (lastGrapple != null && lastGrapple > System.currentTimeMillis() - COOLDOWN_MILISECONDS);
+  }
+}


### PR DESCRIPTION
Gives everyone a rod which acts as a grappling hook (not sure if I've done the kit stuff in the correct format as there seems to be a few ways of doing it but the code works 🤷). Similar functionality to the grappling hooks players may be aware of on Hypixel's Skyblock.

The action of grappling applies velocity to a player when they reel the rod bobber back in depending on the distance they are away from the bobber (how far they threw it). This action has a two-second cooldown which prevents players from getting infinite air time.

~~Going to switch the `playerCooldowns` to a cache so values are cleaned up a bit better than in the `OnlinePlayerMapAdapter`.~~