### PR TITLE
Add support for offline warns and kicks

### DIFF
--- a/src/main/java/dev/pgm/community/moderation/feature/ModerationFeature.java
+++ b/src/main/java/dev/pgm/community/moderation/feature/ModerationFeature.java
@@ -61,6 +61,15 @@ public interface ModerationFeature extends Feature {
   CompletableFuture<Boolean> pardon(String target, Optional<UUID> issuer);
 
   /**
+   * Deactivate an active punishment
+   *
+   * @param target A username or UUID string
+   * @param punishmentType PunishmentType to deactivate
+   * @return True if any punishments were deactivated, false if none
+   */
+  CompletableFuture<Boolean> deactivate(String target, PunishmentType punishmentType);
+
+  /**
    * Get whether the target is currently banned
    *
    * @param target A username or UUID string

--- a/src/main/java/dev/pgm/community/moderation/feature/ModerationFeatureBase.java
+++ b/src/main/java/dev/pgm/community/moderation/feature/ModerationFeatureBase.java
@@ -209,6 +209,10 @@ public abstract class ModerationFeatureBase extends FeatureBase implements Moder
                     .build());
         return;
       }
+    } else if (PunishmentType.WARN.equals(punishment.getType())
+        || PunishmentType.KICK.equals(punishment.getType())) {
+      // If its a warn or kick set it to active so the player sees it when they next login
+      punishment.setActive(true);
     }
 
     save(punishment); // Save punishment to database

--- a/src/main/java/dev/pgm/community/moderation/services/ModerationQuery.java
+++ b/src/main/java/dev/pgm/community/moderation/services/ModerationQuery.java
@@ -20,6 +20,8 @@ public interface ModerationQuery {
       "UPDATE "
           + TABLE_NAME
           + " SET active = ?, last_updated = ?, updated_by = ? WHERE active = ? AND punished = ? ";
+  static final String DEACTIVATE_QUERY =
+      "UPDATE " + TABLE_NAME + " SET active = ?  WHERE active = ? AND punished = ? ";
 
   static final String SELECT_RECENT_QUERY =
       "SELECT * from " + TABLE_NAME + " WHERE time > ? LIMIT ?";

--- a/src/main/java/dev/pgm/community/moderation/services/SQLModerationService.java
+++ b/src/main/java/dev/pgm/community/moderation/services/SQLModerationService.java
@@ -167,6 +167,17 @@ public class SQLModerationService extends SQLFeatureBase<Punishment, String>
         .thenApplyAsync(result -> result != 0);
   }
 
+  public CompletableFuture<Boolean> deactivate(UUID id, PunishmentType punishmentType) {
+    punishmentCache.invalidate(id);
+    return DB.executeUpdateAsync(
+            DEACTIVATE_QUERY + SINGLE_PARDON_TYPE,
+            false,
+            true,
+            id.toString(),
+            punishmentType.toString())
+        .thenApplyAsync(result -> result != 0);
+  }
+
   public CompletableFuture<Boolean> unmute(UUID id, Optional<UUID> issuer) {
     punishmentCache.invalidate(id);
 


### PR DESCRIPTION
This makes it so that when you warn or kick an offline player it performs the punishment action on the player 5 seconds after they next login.

The punishment reason is prefixed with how long ago the punishment was issued.

![warning-test](https://github.com/PGMDev/Community/assets/9834984/e5dea2ca-7e13-4d0f-be8d-6cab39e81d7d)

This is implemented by setting the Warns and Kicks issued while the player is offline to `active = true`. Then when the player next joins, the server checks for all active warns and kicks. It then subsequently executes these punishments and sets `active = false`.

I used the `active` column since it seemed to fit and it meant I didn't need to modify the DB structure.