### PR TITLE
Add a no spawn kit mutation

### DIFF
--- a/src/main/java/dev/pgm/community/mutations/MutationType.java
+++ b/src/main/java/dev/pgm/community/mutations/MutationType.java
@@ -30,7 +30,8 @@ public enum MutationType {
   TNT_BOW("TNT Bow", "All projectiles are TNT", Material.TNT),
   FIREBALL_BOW("Fireball Bow", "All projectiles are fireballs", Material.FIREBALL),
   CANNON_SUPPLIES("Cannon Supplies", "Supplies for making TNT cannons", Material.REDSTONE),
-  GRAPPLING_HOOK("Grappling Hook", "Everyone can use a grappling hook", Material.FISHING_ROD);
+  GRAPPLING_HOOK("Grappling Hook", "Everyone can use a grappling hook", Material.FISHING_ROD),
+  NO_SPAWN_KIT("No Spawn Kit", "No Spawn Kits!", Material.BARRIER);
 
   String displayName;
   String description;

--- a/src/main/java/dev/pgm/community/mutations/feature/MutationFeature.java
+++ b/src/main/java/dev/pgm/community/mutations/feature/MutationFeature.java
@@ -25,6 +25,7 @@ import dev.pgm.community.mutations.types.items.CannonSuppliesMutation;
 import dev.pgm.community.mutations.types.items.ExplosionMutation;
 import dev.pgm.community.mutations.types.items.FireworkMutation;
 import dev.pgm.community.mutations.types.items.GrapplingHookMutation;
+import dev.pgm.community.mutations.types.items.NoSpawnKitMutation;
 import dev.pgm.community.mutations.types.items.PotionMutation;
 import dev.pgm.community.mutations.types.mechanics.BlindMutation;
 import dev.pgm.community.mutations.types.mechanics.DoubleJumpMutation;
@@ -203,6 +204,8 @@ public class MutationFeature extends FeatureBase {
         return new CannonSuppliesMutation(getMatch());
       case GRAPPLING_HOOK:
         return new GrapplingHookMutation(getMatch());
+      case NO_SPAWN_KIT:
+        return new NoSpawnKitMutation(getMatch());
       default:
         logger.warning(type.getDisplayName() + " has not been implemented yet");
     }

--- a/src/main/java/dev/pgm/community/mutations/types/items/NoSpawnKitMutation.java
+++ b/src/main/java/dev/pgm/community/mutations/types/items/NoSpawnKitMutation.java
@@ -1,0 +1,60 @@
+package dev.pgm.community.mutations.types.items;
+
+import com.google.common.collect.Sets;
+import dev.pgm.community.mutations.Mutation;
+import dev.pgm.community.mutations.MutationBase;
+import dev.pgm.community.mutations.MutationType;
+import dev.pgm.community.mutations.options.MutationBooleanOption;
+import dev.pgm.community.mutations.options.MutationOption;
+import java.util.Set;
+import org.bukkit.Material;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.kits.ClearItemsKit;
+import tc.oc.pgm.spawns.events.ParticipantKitApplyEvent;
+
+public class NoSpawnKitMutation extends MutationBase {
+
+  private static final MutationBooleanOption CLEAR_ITEMS_OPTION =
+      new MutationBooleanOption(
+          "Clear Items", "Whether items should be removed", Material.STICK, true, false);
+
+  private static final MutationBooleanOption CLEAR_ARMOR_OPTION =
+      new MutationBooleanOption(
+          "Clear Armor", "Whether armor should be removed", Material.CHAINMAIL_HELMET, true, false);
+
+  private static final MutationBooleanOption CLEAR_EFFECTS_OPTION =
+      new MutationBooleanOption(
+          "Clear Potion Effects",
+          "Whether potion effects should be removed",
+          Material.GLASS_BOTTLE,
+          false,
+          false);
+
+  public NoSpawnKitMutation(Match match) {
+    super(match, MutationType.NO_SPAWN_KIT);
+  }
+
+  @Override
+  public Set<MutationOption> getOptions() {
+    return Sets.newHashSet(CLEAR_ITEMS_OPTION, CLEAR_ARMOR_OPTION, CLEAR_EFFECTS_OPTION);
+  }
+
+  @Override
+  public boolean canEnable(Set<Mutation> existingMutations) {
+    return true;
+  }
+
+  @EventHandler(priority = EventPriority.HIGHEST)
+  public void onSpawn(ParticipantKitApplyEvent event) {
+    event
+        .getPlayer()
+        .applyKit(
+            new ClearItemsKit(
+                CLEAR_ITEMS_OPTION.getValue(),
+                CLEAR_ARMOR_OPTION.getValue(),
+                CLEAR_EFFECTS_OPTION.getValue()),
+            true);
+  }
+}


### PR DESCRIPTION
Adds a mutation that removes spawn kits. Other mutations can still give items on spawn.
Added, this as a way to play old maps as they were originally released, ie without spawn kits, without the need to make separate map variants.

This includes boolean options for items, armor, and potion effects, which toggle whether each one is cleared.