### PR TITLE
Add search flags for /sponsor maps command

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
                         <path>
                             <groupId>cloud.commandframework</groupId>
                             <artifactId>cloud-annotations</artifactId>
-                            <version>1.7.1</version>
+                            <version>1.8.2</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>

--- a/src/main/java/dev/pgm/community/utils/PGMUtils.java
+++ b/src/main/java/dev/pgm/community/utils/PGMUtils.java
@@ -85,7 +85,7 @@ public class PGMUtils {
 
       int max = map.getMaxPlayers().stream().reduce(0, Integer::sum);
       int lowerBound = participants;
-      int upperBound = total + (int) (total * 0.35);
+      int upperBound = Math.max(5, total + (int) (total * 0.35));
 
       return max >= lowerBound && max <= upperBound;
     }


### PR DESCRIPTION
Adds the search flags from the PGM `/maps` command to `/sponsor maps`.

### Notes:
- The map list in the `/sponsor maps` command is now sorted.
- Raised the minimum upper bound for map size to 5.
- Updated cloud-annotations to match PGM's version