### PR TITLE
Add team size autoscaling for events

### DIFF
--- a/src/main/java/dev/pgm/community/party/MapParty.java
+++ b/src/main/java/dev/pgm/community/party/MapParty.java
@@ -27,6 +27,10 @@ public interface MapParty {
 
   void setDescription(String description);
 
+  boolean shouldAutoScale();
+
+  void setAutoScaling(boolean autoScaling);
+
   @Nullable
   Duration getLength();
 

--- a/src/main/java/dev/pgm/community/party/MapPartyBase.java
+++ b/src/main/java/dev/pgm/community/party/MapPartyBase.java
@@ -27,6 +27,7 @@ public abstract class MapPartyBase implements MapParty {
   private MapPartySettings settings;
   private boolean running;
   private boolean setup;
+  private boolean autoScaling;
 
   private Instant startTime;
 
@@ -43,6 +44,7 @@ public abstract class MapPartyBase implements MapParty {
     this.settings = settings;
     this.running = false;
     this.setup = false;
+    this.autoScaling = true;
     this.startTime = null;
   }
 
@@ -70,6 +72,16 @@ public abstract class MapPartyBase implements MapParty {
   @Override
   public String getDescription() {
     return description;
+  }
+
+  @Override
+  public boolean shouldAutoScale() {
+    return autoScaling;
+  }
+
+  @Override
+  public void setAutoScaling(boolean autoScaling) {
+    this.autoScaling = autoScaling;
   }
 
   @Override

--- a/src/main/java/dev/pgm/community/party/MapPartyCommands.java
+++ b/src/main/java/dev/pgm/community/party/MapPartyCommands.java
@@ -221,6 +221,13 @@ public class MapPartyCommands extends CommunityCommand {
     party.toggleMultiplier(viewer);
   }
 
+  @CommandMethod("autoscaling <autoscale>")
+  @CommandPermission(CommunityPermissions.PARTY)
+  public void toggleAutoScale(CommandAudience viewer, @Argument("autoscale") boolean autoscaling) {
+    if (isPartyMissing(viewer)) return;
+    party.setAutoScale(viewer, autoscaling);
+  }
+
   private boolean isPartyMissing(CommandAudience viewer) {
     if (party.getParty() == null) {
       viewer.sendWarning(MapPartyMessages.MISSING_ERROR);

--- a/src/main/java/dev/pgm/community/party/menu/settings/MapPartySettingsMenu.java
+++ b/src/main/java/dev/pgm/community/party/menu/settings/MapPartySettingsMenu.java
@@ -49,6 +49,7 @@ public class MapPartySettingsMenu extends MapPartyMenu {
     MapParty party = getFeature().getParty();
     MapPartySettings settings = party.getSettings();
 
+    contents.set(1, 1, getAutoScalingItem(settings.getAutoscalingTeams()));
     contents.set(3, 1, getNameItem(party));
     contents.set(3, 3, getTimelimitItem(party));
     contents.set(3, 5, getSettingItem(settings.getShowLoginMessage()));
@@ -194,18 +195,27 @@ public class MapPartySettingsMenu extends MapPartyMenu {
   }
 
   private ClickableItem getSettingItem(PartyBooleanSetting setting) {
+    return ClickableItem.of(settingItemBuilder(setting), c -> setting.toggle());
+  }
+
+  private ClickableItem getAutoScalingItem(PartyBooleanSetting setting) {
     return ClickableItem.of(
-        new ItemBuilder()
-            .material(setting.getIcon())
-            .name(colorize((setting.getValue() ? "&a&l" : "&c&l") + setting.getName()))
-            .lore(
-                colorize("&7" + setting.getDescription()),
-                colorize("&7Current: " + (setting.getValue() ? "&aEnabled" : "&cDisabled")),
-                colorize("&7Click to toggle"))
-            .flags(ItemFlag.values())
-            .build(),
+        settingItemBuilder(setting),
         c -> {
           setting.toggle();
+          Bukkit.dispatchCommand(getViewer(), "event autoscaling " + setting.getValue());
         });
+  }
+
+  private static ItemStack settingItemBuilder(PartyBooleanSetting setting) {
+    return new ItemBuilder()
+        .material(setting.getIcon())
+        .name(colorize((setting.getValue() ? "&a&l" : "&c&l") + setting.getName()))
+        .lore(
+            colorize("&7" + setting.getDescription()),
+            colorize("&7Current: " + (setting.getValue() ? "&aEnabled" : "&cDisabled")),
+            colorize("&7Click to toggle"))
+        .flags(ItemFlag.values())
+        .build();
   }
 }

--- a/src/main/java/dev/pgm/community/party/settings/MapPartySettings.java
+++ b/src/main/java/dev/pgm/community/party/settings/MapPartySettings.java
@@ -7,6 +7,7 @@ public class MapPartySettings {
 
   private PartyBooleanSetting showLoginMessage;
   private PartyBooleanSetting showPartyNotifications;
+  private PartyBooleanSetting autoscalingTeams;
 
   public MapPartySettings(MapPartyConfig config) {
     this.showLoginMessage =
@@ -23,6 +24,13 @@ public class MapPartySettings {
             config.showPartyNotifications(),
             Material.BOOK_AND_QUILL,
             Material.BARRIER);
+    this.autoscalingTeams =
+        new PartyBooleanSetting(
+            "Autoscaling Teams",
+            "Automatically resize teams on match cycle",
+            true,
+            Material.GOLD_PLATE,
+            Material.WOOD_PLATE);
   }
 
   public PartyBooleanSetting getShowLoginMessage() {
@@ -31,5 +39,9 @@ public class MapPartySettings {
 
   public PartyBooleanSetting getShowPartyNotifications() {
     return showPartyNotifications;
+  }
+
+  public PartyBooleanSetting getAutoscalingTeams() {
+    return autoscalingTeams;
   }
 }


### PR DESCRIPTION
Adds team size autoscaling for map parties.
It's a toggleable setting, that defaults to true.

If the match max player size is less than the number of online players it will scale the team / FFA size to match the player count.

This should cut down on the effect of mods forgetting to adjust team sizes during map party events.