### PR TITLE
Add 3/5 (60%) voting threshold for polls

### DIFF
--- a/src/main/java/dev/pgm/community/polls/PollThreshold.java
+++ b/src/main/java/dev/pgm/community/polls/PollThreshold.java
@@ -8,8 +8,9 @@ import net.kyori.adventure.text.format.NamedTextColor;
 public enum PollThreshold {
   CLEAR_MINORITY("Clear Minority", 0.25, NamedTextColor.DARK_GREEN),
   SIMPLE("Simple Majority", 0.5, NamedTextColor.GREEN),
-  TWO_THIRDS("2/3 Majority", 0.6667, NamedTextColor.YELLOW),
-  STRONG_MAJORITY("Strong Majority", 0.75, NamedTextColor.GOLD);
+  THREE_FIFTHS("3/5 Majority", 0.6, NamedTextColor.GOLD),
+  TWO_THIRDS("2/3 Majority", 0.6667, NamedTextColor.RED),
+  STRONG_MAJORITY("Strong Majority", 0.75, NamedTextColor.DARK_RED);
 
   private final String displayName;
   private final double value;


### PR DESCRIPTION
Adds a 3/5 voting threshold for polls.

Example voting:

- 50% 
    - Ex: 10 v 10
- 3/5
    - Ex: 15 v 10
- 2/3
    - Ex: 20 v 10

There are some votes where 2/3 is overkill but 50% is insufficient. This adds a middle ground.

Also slightly modified the colors.