### PR TITLE
Add ban time and reason as hover to /alts

### DIFF
--- a/src/main/java/dev/pgm/community/moderation/feature/ModerationFeature.java
+++ b/src/main/java/dev/pgm/community/moderation/feature/ModerationFeature.java
@@ -86,6 +86,14 @@ public interface ModerationFeature extends Feature {
   CompletableFuture<Optional<Punishment>> isMuted(UUID target);
 
   /**
+   * Gets active ban for the provided UUID, if any
+   *
+   * @param target A username or UUID string
+   * @return An optional {@link Punishment}
+   */
+  CompletableFuture<Optional<Punishment>> getActiveBan(String target);
+
+  /**
    * Unmutes any active mutes for the provided target
    *
    * @param target A player UUID

--- a/src/main/java/dev/pgm/community/moderation/feature/types/SQLModerationFeature.java
+++ b/src/main/java/dev/pgm/community/moderation/feature/types/SQLModerationFeature.java
@@ -144,6 +144,20 @@ public class SQLModerationFeature extends ModerationFeatureBase {
   }
 
   @Override
+  public CompletableFuture<Optional<Punishment>> getActiveBan(String target) {
+    if (NameUtils.isMinecraftName(target)) {
+      return getUsers()
+          .getStoredId(target)
+          .thenApplyAsync(
+              uuid ->
+                  uuid.isPresent()
+                      ? service.getActiveBan(uuid.get().toString()).join()
+                      : Optional.empty());
+    }
+    return service.getActiveBan(target);
+  }
+
+  @Override
   public void onPreLogin(AsyncPlayerPreLoginEvent event) {
     List<Punishment> punishments;
     try {

--- a/src/main/java/dev/pgm/community/moderation/punishments/Punishment.java
+++ b/src/main/java/dev/pgm/community/moderation/punishments/Punishment.java
@@ -212,7 +212,7 @@ public class Punishment implements Comparable<Punishment> {
     placeholders.put("%type%", getType().getPunishmentPrefix());
     placeholders.put("%full_type%", getType().getPunishmentPrefix());
     if (this.getDuration() != null) {
-      placeholders.put("%full_type%", formatTimeComponent(getDuration()));
+      placeholders.put("%full_type%", formatTimeComponent());
     }
     placeholders.put("%target%", target);
     placeholders.put("%reason%", text(getReason(), NamedTextColor.RED));
@@ -233,7 +233,7 @@ public class Punishment implements Comparable<Punishment> {
     return builder.build();
   }
 
-  private Component formatTimeComponent(Duration duration) {
+  public Component formatTimeComponent() {
     Duration length = this.getDuration();
     String time = TextTranslations.translateLegacy(duration(length));
 

--- a/src/main/java/dev/pgm/community/moderation/services/SQLModerationService.java
+++ b/src/main/java/dev/pgm/community/moderation/services/SQLModerationService.java
@@ -218,6 +218,19 @@ public class SQLModerationService extends SQLFeatureBase<Punishment, String>
             });
   }
 
+  public CompletableFuture<Optional<Punishment>> getActiveBan(String id) {
+    return queryList(id)
+        .thenApplyAsync(
+            punishments -> {
+              for (Punishment p : punishments) {
+                if (p.getType().isLoginPrevented() && p.isActive()) {
+                  return Optional.of(p);
+                }
+              }
+              return Optional.empty();
+            });
+  }
+
   public CompletableFuture<List<Punishment>> getRecentPunishments(Duration period) {
     return DB.getResultsAsync(
             SELECT_RECENT_QUERY, Instant.now().toEpochMilli() - period.toMillis(), RECENT_LIMIT)


### PR DESCRIPTION
Adds a hover to `/alts` that gives the punishment time and reason for banned alts.

How it looks:

<img width="724" alt="Screenshot 2024-01-20 at 4 59 24 PM" src="https://github.com/PGMDev/Community/assets/9834984/cd21e747-e24f-4e37-b624-8d34fab6e777">
