### PR TITLE
Allow /nicks to be used by all players and display player nicknames

### DIFF
--- a/src/main/java/dev/pgm/community/nick/commands/NickCommands.java
+++ b/src/main/java/dev/pgm/community/nick/commands/NickCommands.java
@@ -26,6 +26,7 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+import tc.oc.pgm.api.integration.Integration;
 import tc.oc.pgm.lib.cloud.commandframework.annotations.Argument;
 import tc.oc.pgm.lib.cloud.commandframework.annotations.CommandDescription;
 import tc.oc.pgm.lib.cloud.commandframework.annotations.CommandMethod;
@@ -386,12 +387,13 @@ public class NickCommands extends CommunityCommand {
   @ProxiedBy("nicks")
   @CommandMethod("list")
   @CommandDescription("View a list of online nicked players")
-  @CommandPermission(CommunityPermissions.STAFF)
   public void viewNicks(CommandAudience viewer) {
+    boolean staff = viewer.hasPermission(CommunityPermissions.STAFF);
     List<Component> nickedNames =
         Bukkit.getOnlinePlayers().stream()
+            .filter(player -> staff || Integration.isFriend(player, viewer.getPlayer()))
             .filter(player -> nicks.isNicked(player.getUniqueId()))
-            .map(player -> PlayerComponent.player(player, NameStyle.FANCY))
+            .map(player -> PlayerComponent.player(player, NameStyle.VERBOSE))
             .collect(Collectors.toList());
 
     if (nickedNames.isEmpty()) {


### PR DESCRIPTION
`/nicks` displays the full names (username and nickname) of:
- all players when ran by staff
- all friends when ran by a player