### PR TITLE
Allow players with pgm.staff permission node to view disguised players' nicks and skins

### DIFF
--- a/src/main/java/dev/pgm/community/nick/skin/SkinCache.java
+++ b/src/main/java/dev/pgm/community/nick/skin/SkinCache.java
@@ -107,7 +107,9 @@ public class SkinCache implements Listener {
   private void refreshFakeName(Player player, Player viewer) {
     boolean nicked = Integration.getNick(player) != null;
     boolean areFriends = Integration.isFriend(player, viewer);
-    boolean canOverride = viewer.hasPermission(CommunityPermissions.NICKNAME_VIEW);
+    boolean canOverride =
+        viewer.hasPermission(Permissions.STAFF)
+            || viewer.hasPermission(CommunityPermissions.NICKNAME_VIEW);
 
     boolean canSeeRealName = (canOverride || player == viewer || areFriends);
 


### PR DESCRIPTION
If you have the permission node `pgm.staff`, [you can see through nicks](https://github.com/PGMDev/PGM/blob/dev/core/src/main/java/tc/oc/pgm/util/Players.java#L27) in tab list, commands and chat. However, since Community uses the permission node `community.nick.view-skins` when setting a fake name and skin, it is possible to see through nicknames in PGM, but still see the fake player model.