### PR TITLE
Add /vanished command

### DIFF
--- a/src/main/java/dev/pgm/community/commands/VanishedCommand.java
+++ b/src/main/java/dev/pgm/community/commands/VanishedCommand.java
@@ -1,0 +1,48 @@
+package dev.pgm.community.commands;
+
+import static net.kyori.adventure.text.Component.text;
+
+import dev.pgm.community.CommunityCommand;
+import dev.pgm.community.CommunityPermissions;
+import dev.pgm.community.utils.CommandAudience;
+import java.util.List;
+import java.util.stream.Collectors;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Bukkit;
+import tc.oc.pgm.api.integration.Integration;
+import tc.oc.pgm.lib.cloud.commandframework.annotations.CommandDescription;
+import tc.oc.pgm.lib.cloud.commandframework.annotations.CommandMethod;
+import tc.oc.pgm.lib.cloud.commandframework.annotations.CommandPermission;
+import tc.oc.pgm.util.named.NameStyle;
+import tc.oc.pgm.util.player.PlayerComponent;
+import tc.oc.pgm.util.text.TextFormatter;
+
+public class VanishedCommand extends CommunityCommand {
+  @CommandMethod("vanished")
+  @CommandDescription("View a list of online vanished players")
+  @CommandPermission(CommunityPermissions.VIEW_VANISHED)
+  public void viewVanished(CommandAudience viewer) {
+    List<Component> vanishedNames =
+        Bukkit.getOnlinePlayers().stream()
+            .filter(Integration::isVanished)
+            .map(player -> PlayerComponent.player(player, NameStyle.VERBOSE))
+            .collect(Collectors.toList());
+
+    if (vanishedNames.isEmpty()) {
+      viewer.sendWarning(text("No online players are vanished!"));
+      return;
+    }
+
+    Component count =
+        text()
+            .append(text("Vanished", NamedTextColor.DARK_AQUA))
+            .append(text(": "))
+            .append(text(vanishedNames.size()))
+            .build();
+    Component nameList = TextFormatter.list(vanishedNames, NamedTextColor.GRAY);
+
+    viewer.sendMessage(count);
+    viewer.sendMessage(nameList);
+  }
+}

--- a/src/main/java/dev/pgm/community/commands/graph/CommunityCommandGraph.java
+++ b/src/main/java/dev/pgm/community/commands/graph/CommunityCommandGraph.java
@@ -14,6 +14,7 @@ import dev.pgm.community.commands.GamemodeCommand;
 import dev.pgm.community.commands.ServerInfoCommand;
 import dev.pgm.community.commands.StaffCommand;
 import dev.pgm.community.commands.SudoCommand;
+import dev.pgm.community.commands.VanishedCommand;
 import dev.pgm.community.commands.injectors.CommandAudienceProvider;
 import dev.pgm.community.commands.player.TargetPlayer;
 import dev.pgm.community.commands.providers.GameModeParser;
@@ -171,6 +172,7 @@ public class CommunityCommandGraph extends CommandGraph<Community> {
     register(new ServerInfoCommand());
     register(new StaffCommand());
     register(new SudoCommand());
+    register(new VanishedCommand());
 
     // Community plugin command
     register(new CommunityPluginCommand());


### PR DESCRIPTION
Allows you to see a list of online vanished players, much like `/nicks` does with nicked players.