### PR TITLE
Disable requests by default on startup

### DIFF
--- a/src/main/java/dev/pgm/community/requests/feature/RequestFeatureBase.java
+++ b/src/main/java/dev/pgm/community/requests/feature/RequestFeatureBase.java
@@ -101,7 +101,6 @@ public abstract class RequestFeatureBase extends FeatureBase implements RequestF
     this.sponsors = Lists.newLinkedList();
     this.currentSponsor = null;
     this.bookCreator = new SponsorVotingBookCreator(this);
-    this.accepting = true;
 
     if (getConfig().isEnabled() && PGMUtils.isPGMEnabled()) {
       enable();


### PR DESCRIPTION
Currently requests keep enabling themselves on restart even tho they should be used sparingly and mainly during events. This fixes the default so they're disabled on startup, and can instead be enabled by mods when they want to run a party/event that takes requests in.