### PR TITLE
Switch parts of config parsing to PGMs TextParser.parseComponent

### DIFF
--- a/src/main/java/dev/pgm/community/broadcast/BroadcastConfig.java
+++ b/src/main/java/dev/pgm/community/broadcast/BroadcastConfig.java
@@ -1,8 +1,13 @@
 package dev.pgm.community.broadcast;
 
+import static tc.oc.pgm.util.text.TextParser.parseComponent;
+
 import dev.pgm.community.feature.config.FeatureConfigImpl;
 import java.util.List;
+import java.util.stream.Collectors;
+import net.kyori.adventure.text.Component;
 import org.bukkit.configuration.Configuration;
+import tc.oc.pgm.util.text.TextParser;
 
 public class BroadcastConfig extends FeatureConfigImpl {
 
@@ -15,8 +20,8 @@ public class BroadcastConfig extends FeatureConfigImpl {
 
   private boolean announceEnabled;
   private int announceDelay;
-  private String announcePrefix;
-  private List<String> announceMessages;
+  private Component announcePrefix;
+  private List<Component> announceMessages;
 
   public BroadcastConfig(Configuration config) {
     super(KEY, config);
@@ -42,11 +47,11 @@ public class BroadcastConfig extends FeatureConfigImpl {
     return announceDelay;
   }
 
-  public String getAnnouncePrefix() {
+  public Component getAnnouncePrefix() {
     return announcePrefix;
   }
 
-  public List<String> getAnnounceMessages() {
+  public List<Component> getAnnounceMessages() {
     return announceMessages;
   }
 
@@ -63,7 +68,10 @@ public class BroadcastConfig extends FeatureConfigImpl {
 
     this.announceEnabled = config.getBoolean(getAnnounceKey() + ".enabled");
     this.announceDelay = config.getInt(getAnnounceKey() + ".delay-seconds");
-    this.announcePrefix = config.getString(getAnnounceKey() + ".prefix");
-    this.announceMessages = config.getStringList(getAnnounceKey() + ".messages");
+    this.announcePrefix = parseComponent(config.getString(getAnnounceKey() + ".prefix"));
+    this.announceMessages =
+        config.getStringList(getAnnounceKey() + ".messages").stream()
+            .map(TextParser::parseComponent)
+            .collect(Collectors.toList());
   }
 }

--- a/src/main/java/dev/pgm/community/broadcast/BroadcastFeature.java
+++ b/src/main/java/dev/pgm/community/broadcast/BroadcastFeature.java
@@ -55,14 +55,13 @@ public class BroadcastFeature extends FeatureBase {
     if (!getBroadcastConfig().isAnnounceEnabled()) return;
     if (getBroadcastConfig().getAnnounceMessages().isEmpty()) return;
     Duration timeSince = Duration.between(lastAnnounce, Instant.now());
-    List<String> messages = getBroadcastConfig().getAnnounceMessages();
+    List<Component> messages = getBroadcastConfig().getAnnounceMessages();
 
     if (timeSince.getSeconds() > getBroadcastConfig().getAnnounceDelay()) {
       if (lastAnnounceIndex >= messages.size()) lastAnnounceIndex = 0;
-      String msg = messages.get(lastAnnounceIndex);
-      Component prefix = text(colorize(getBroadcastConfig().getAnnouncePrefix()));
-      Component message = text(colorize(msg));
-      BroadcastUtils.sendGlobalMessage(text().append(prefix).append(message).build());
+      Component prefix = getBroadcastConfig().getAnnouncePrefix();
+      BroadcastUtils.sendGlobalMessage(
+          text().append(prefix).append(messages.get(lastAnnounceIndex)).build());
       lastAnnounceIndex++;
       lastAnnounce = Instant.now();
     }

--- a/src/main/java/dev/pgm/community/info/InfoCommandData.java
+++ b/src/main/java/dev/pgm/community/info/InfoCommandData.java
@@ -3,10 +3,12 @@ package dev.pgm.community.info;
 import static net.kyori.adventure.text.Component.text;
 
 import java.util.List;
+import java.util.stream.Collectors;
+import net.kyori.adventure.text.Component;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.ConfigurationSection;
 import tc.oc.pgm.util.Audience;
-import tc.oc.pgm.util.bukkit.BukkitUtils;
+import tc.oc.pgm.util.text.TextParser;
 
 public class InfoCommandData {
 
@@ -14,10 +16,10 @@ public class InfoCommandData {
   private static final String PERMISSION_KEY = "permission";
 
   private String name;
-  private List<String> lines;
+  private List<Component> lines;
   private String permission;
 
-  public InfoCommandData(String name, List<String> lines, String permission) {
+  public InfoCommandData(String name, List<Component> lines, String permission) {
     this.name = name;
     this.lines = lines;
     this.permission = permission;
@@ -25,14 +27,18 @@ public class InfoCommandData {
 
   public static InfoCommandData of(ConfigurationSection section) {
     return new InfoCommandData(
-        section.getName(), section.getStringList(LINES_KEY), section.getString(PERMISSION_KEY));
+        section.getName(),
+        section.getStringList(LINES_KEY).stream()
+            .map(TextParser::parseComponent)
+            .collect(Collectors.toList()),
+        section.getString(PERMISSION_KEY));
   }
 
   public String getName() {
     return name;
   }
 
-  public List<String> getLines() {
+  public List<Component> getLines() {
     return lines;
   }
 
@@ -50,9 +56,6 @@ public class InfoCommandData {
       }
     }
 
-    getLines().stream()
-        .map(BukkitUtils::colorize)
-        .map(msg -> text(msg))
-        .forEach(viewer::sendMessage);
+    getLines().forEach(viewer::sendMessage);
   }
 }

--- a/src/main/java/dev/pgm/community/motd/MotdConfig.java
+++ b/src/main/java/dev/pgm/community/motd/MotdConfig.java
@@ -2,25 +2,31 @@ package dev.pgm.community.motd;
 
 import dev.pgm.community.feature.config.FeatureConfigImpl;
 import java.util.List;
+import java.util.stream.Collectors;
+import net.kyori.adventure.text.Component;
 import org.bukkit.configuration.Configuration;
+import tc.oc.pgm.util.text.TextParser;
 
 public class MotdConfig extends FeatureConfigImpl {
 
   private static final String KEY = "motd";
 
-  private List<String> lines;
+  private List<Component> lines;
 
   public MotdConfig(Configuration config) {
     super(KEY, config);
   }
 
-  public List<String> getLines() {
+  public List<Component> getLines() {
     return lines;
   }
 
   @Override
   public void reload(Configuration config) {
     super.reload(config);
-    this.lines = config.getStringList(getKey() + ".lines");
+    this.lines =
+        config.getStringList(getKey() + ".lines").stream()
+            .map(TextParser::parseComponent)
+            .collect(Collectors.toList());
   }
 }

--- a/src/main/java/dev/pgm/community/motd/MotdFeature.java
+++ b/src/main/java/dev/pgm/community/motd/MotdFeature.java
@@ -6,7 +6,7 @@ import org.bukkit.configuration.Configuration;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.player.PlayerJoinEvent;
-import tc.oc.pgm.util.bukkit.BukkitUtils;
+import tc.oc.pgm.util.Audience;
 
 /** MotdFeature - Displays a configurable message at login * */
 public class MotdFeature extends FeatureBase {
@@ -25,8 +25,7 @@ public class MotdFeature extends FeatureBase {
   @EventHandler(priority = EventPriority.LOW)
   public void onPlayerJoin(PlayerJoinEvent event) {
     if (getMotdConfig().getLines().isEmpty()) return;
-    for (String line : getMotdConfig().getLines()) {
-      event.getPlayer().sendMessage(BukkitUtils.colorize(line));
-    }
+    Audience audience = Audience.get(event.getPlayer());
+    getMotdConfig().getLines().forEach(audience::sendMessage);
   }
 }


### PR DESCRIPTION
Switches some config messages to [TextParser.parseString](https://github.com/PGMDev/PGM/blob/dev/util/src/main/java/tc/oc/pgm/util/text/TextParser.java#L416)

This method accepts the old legacy strings and handles them the same way, which prevents this from breaking old Community configs. The main difference is that this can now also accept Minecraft JSON formatted strings.

This is the same parser the `<text>` XML component uses.

Really basic example:

<img width="356" alt="Screenshot 2024-05-25 at 6 51 00 PM" src="https://github.com/PGMDev/Community/assets/9834984/e0066ddf-0196-41f1-91de-994f774a9719">

The main reason for making this change is that /ranks does not have the same hover messages as normal chat ranks.
