### PR TITLE
Only show staff in event host add menu

### DIFF
--- a/src/main/java/dev/pgm/community/menu/PlayerSelectionProvider.java
+++ b/src/main/java/dev/pgm/community/menu/PlayerSelectionProvider.java
@@ -13,6 +13,7 @@ import fr.minuskube.inv.content.SlotIterator;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -40,7 +41,7 @@ public abstract class PlayerSelectionProvider implements InventoryProvider {
   @Override
   public void init(Player player, InventoryContents contents) {
     Pagination page = contents.pagination();
-    page.setItems(getAllPlayers(player));
+    page.setItems(getFilteredPlayers(player));
     page.setItemsPerPage(45);
 
     page.addToIterator(contents.newIterator(SlotIterator.Type.HORIZONTAL, 0, 0));
@@ -84,16 +85,18 @@ public abstract class PlayerSelectionProvider implements InventoryProvider {
     return stack;
   }
 
-  private Comparator<Player> COMPARE =
-      Comparator.comparing(
-          Player::getName,
-          (p1, p2) -> {
-            return p1.compareToIgnoreCase(p2);
-          });
+  private final Comparator<Player> COMPARE =
+      Comparator.comparing(Player::getName, String::compareToIgnoreCase);
 
-  private ClickableItem[] getAllPlayers(Player viewer) {
-    List<Player> online =
-        Bukkit.getOnlinePlayers().stream().sorted(COMPARE).collect(Collectors.toList());
+  public Predicate<Player> relevantPlayerFilter() {
+    return (player) -> true;
+  }
+
+  private ClickableItem[] getFilteredPlayers(Player viewer) {
+    List<Player> online = Bukkit.getOnlinePlayers().stream()
+        .filter(relevantPlayerFilter())
+        .sorted(COMPARE)
+        .collect(Collectors.toList());
     ClickableItem[] items = new ClickableItem[online.size()];
     for (int i = 0; i < online.size(); i++) {
       Player player = online.get(i);

--- a/src/main/java/dev/pgm/community/party/menu/hosts/HostAddMenu.java
+++ b/src/main/java/dev/pgm/community/party/menu/hosts/HostAddMenu.java
@@ -12,6 +12,7 @@ import fr.minuskube.inv.SmartInventory;
 import fr.minuskube.inv.content.InventoryContents;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -24,26 +25,26 @@ public class HostAddMenu extends PlayerSelectionProvider {
 
   public HostAddMenu(MapPartyHosts hosts) {
     this.hosts = hosts;
-    this.inventory =
-        SmartInventory.builder()
-            .size(6, 9)
-            .manager(Community.get().getInventory())
-            .provider(this)
-            .title(colorize("&a&lAdd New Host&7:"))
-            .build();
+    this.inventory = SmartInventory.builder()
+        .size(6, 9)
+        .manager(Community.get().getInventory())
+        .provider(this)
+        .title(colorize("&a&lAdd New Host&7:"))
+        .build();
   }
 
   @Override
   public void init(Player player, InventoryContents contents) {
     super.init(player, contents);
     contents.set(
-        5,
-        4,
-        ClickableItem.of(
-            getNamedItem("&7Return to &aEvent Hosts", Material.CAKE, 1),
-            c -> {
-              Bukkit.dispatchCommand(player, "event hosts");
-            }));
+        5, 4, ClickableItem.of(getNamedItem("&7Return to &aEvent Hosts", Material.CAKE, 1), c -> {
+          Bukkit.dispatchCommand(player, "event hosts");
+        }));
+  }
+
+  @Override
+  public Predicate<Player> relevantPlayerFilter() {
+    return player -> player.hasPermission(CommunityPermissions.STAFF);
   }
 
   @Override
@@ -65,10 +66,7 @@ public class HostAddMenu extends PlayerSelectionProvider {
   @Override
   public List<String> getPlayerLore(Player viewer, Player player) {
     boolean isHost = hosts.isHost(player.getUniqueId());
-    return Lists.newArrayList(
-        colorize(
-            isHost
-                ? "&cAlready a host"
-                : "&aClick to make " + player.getDisplayName() + " &aa host"));
+    return Lists.newArrayList(colorize(
+        isHost ? "&cAlready a host" : "&aClick to make " + player.getDisplayName() + " &aa host"));
   }
 }


### PR DESCRIPTION
Restricts the event hosts add menu to only show staff. Its currently not very useful given how many nonstaff you have to search through to use it.