### PR TITLE
Improvements to sponsor map constraints

### DIFF
--- a/src/main/java/dev/pgm/community/requests/RequestConfig.java
+++ b/src/main/java/dev/pgm/community/requests/RequestConfig.java
@@ -23,6 +23,8 @@ public class RequestConfig extends FeatureConfigImpl {
   private static final String MAX_TOKENS = SPONSORS + ".max-tokens";
   private static final String REFUND = SPONSORS + ".refund";
   private static final String MAP_COOLDOWN_MULTIPLY = SPONSORS + ".map-cooldown";
+  private static final String LOWER_LIMIT_OFFSET = SPONSORS + ".lower-limit-offset";
+  private static final String UPPER_LIMIT_OFFSET = SPONSORS + ".upper-limit-offset";
 
   private Duration cooldown; // Cooldown for using /request
   private Duration sponsorCooldown; // Default cooldown for sponsor requests
@@ -39,6 +41,9 @@ public class RequestConfig extends FeatureConfigImpl {
   private boolean refund; // If token should be refunded when vote is successful
 
   private int mapCooldownMultiply; // # to multiply match length by to determine cooldown
+
+  private int lowerLimitOffset; // Offset to apply on match end to lower map size bound
+  private int upperLimitOffset; // Offset to apply on match end to upper map size bound
 
   public RequestConfig(Configuration config) {
     super(KEY, config);
@@ -92,6 +97,14 @@ public class RequestConfig extends FeatureConfigImpl {
     return mapCooldownMultiply;
   }
 
+  public int getLowerLimitOffset() {
+    return lowerLimitOffset;
+  }
+
+  public int getUpperLimitOffset() {
+    return upperLimitOffset;
+  }
+
   @Override
   public void reload(Configuration config) {
     super.reload(config);
@@ -104,5 +117,7 @@ public class RequestConfig extends FeatureConfigImpl {
     this.maxQueue = config.getInt(SPONSORS_LIMIT);
     this.refund = config.getBoolean(REFUND);
     this.mapCooldownMultiply = config.getInt(MAP_COOLDOWN_MULTIPLY);
+    this.lowerLimitOffset = config.getInt(LOWER_LIMIT_OFFSET);
+    this.upperLimitOffset = config.getInt(UPPER_LIMIT_OFFSET);
   }
 }

--- a/src/main/java/dev/pgm/community/requests/feature/RequestFeature.java
+++ b/src/main/java/dev/pgm/community/requests/feature/RequestFeature.java
@@ -6,6 +6,7 @@ import dev.pgm.community.feature.Feature;
 import dev.pgm.community.requests.MapCooldown;
 import dev.pgm.community.requests.RequestProfile;
 import dev.pgm.community.requests.SponsorRequest;
+import dev.pgm.community.utils.PGMUtils.MapSizeBounds;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -149,4 +150,6 @@ public interface RequestFeature extends Feature {
   void openMenu(Player player);
 
   List<MapInfo> getAvailableSponsorMaps();
+
+  MapSizeBounds getCurrentMapSizeBounds();
 }

--- a/src/main/java/dev/pgm/community/requests/feature/SponsorVotingBookCreator.java
+++ b/src/main/java/dev/pgm/community/requests/feature/SponsorVotingBookCreator.java
@@ -31,7 +31,7 @@ public class SponsorVotingBookCreator extends VotingBookCreatorImpl {
       return text()
           .append(originalHover)
           .append(newline())
-          .append(text("+ ", NamedTextColor.GREEN, TextDecoration.BOLD))
+          .append(text("+ ", NamedTextColor.YELLOW, TextDecoration.BOLD))
           .append(text("Sponsored by ", NamedTextColor.GRAY))
           .append(player(sponsor.getPlayerId(), NameStyle.FANCY))
           .build();

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -208,7 +208,11 @@ requests:
     weekly-tokens: 1   # Amount of tokens given on a weekly basis (community.token.weekly perm)
     max-tokens: 7      # Maximum amount of tokens an account can collect
     refund: true       # Tokens are refunded when map vote is successful
-
+    
+    # Sponsor bound offset used to modify avaiable maps at the end of each match
+    lower-limit-offset: 4   # Subtracted from the current minimum
+    upper-limit-offset: 8   # Added to the current maximum
+    
 # Mobs - Spawn creatures that will attack players ;)
 mobs:
   enabled: true


### PR DESCRIPTION
This PR addresses several long-standing issues related to sponsoring constraints and implements the following changes:

- Map variants are now considered under cooldown if any variant of said map has recently been played.
- Removed the 30-second match start requirement; players can now sponsor a map at any given point.
- Removed sponsor logic that discarded existing sponsor requests not within online player bounds. Now, all sponsor requests remain in the queue until they're able to play (if possible). Additionally, an alert is sent upon the selection of the sponsor map each map vote that informs the user and offers a quick button to cancel and select another map.
- Added an upper and lower limit offset to apply to the min/max bounds of the available maps only after the current match has ended.
- Improved visibility of the current online player range in error messages and the sponsor map list command.
