### PR TITLE
Use PlayerComponent.CONSOLE for console punishments

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -83,6 +83,20 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>22.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.incendo</groupId>
+            <artifactId>cloud-annotations</artifactId>
+            <version>2.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/core/src/main/java/dev/pgm/community/moderation/punishments/Punishment.java
+++ b/core/src/main/java/dev/pgm/community/moderation/punishments/Punishment.java
@@ -37,7 +37,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.util.Audience;
-import tc.oc.pgm.util.UsernameFormatUtils;
 import tc.oc.pgm.util.named.NameStyle;
 import tc.oc.pgm.util.player.PlayerComponent;
 import tc.oc.pgm.util.text.TemporalComponent;
@@ -174,7 +173,7 @@ public class Punishment implements Comparable<Punishment> {
           .kickPlayer(formatPunishmentScreen(
               getConfig(),
               isConsole()
-                  ? UsernameFormatUtils.CONSOLE_NAME
+                  ? PlayerComponent.CONSOLE
                   : PlayerComponent.player(getIssuerId(), NameStyle.FANCY),
               silent));
       return true;

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,21 @@
             <version>1.0.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>22.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.incendo</groupId>
+            <artifactId>cloud-annotations</artifactId>
+            <version>2.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+
     </dependencies>
 
     <build>


### PR DESCRIPTION
`UsernameFormatUtils.CONSOLE_NAME` no longer exists in upstream PGM so this PR switches to `PlayerComponent.CONSOLE`

~~This is a draft PR as it is on top of a rebase of the Gradle migration PR.~~

This PR requires that upstream PGM is deployed to repo.pgm.fyi before merging.
