### PR TITLE
Show sponsor cooldowns & fix their logic

### DIFF
--- a/core/src/main/java/dev/pgm/community/requests/commands/RequestCommands.java
+++ b/core/src/main/java/dev/pgm/community/requests/commands/RequestCommands.java
@@ -23,6 +23,7 @@ import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.entity.Player;
+import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.map.MapInfo;
 import tc.oc.pgm.lib.org.incendo.cloud.annotation.specifier.Greedy;
 import tc.oc.pgm.lib.org.incendo.cloud.annotations.Argument;
@@ -55,16 +56,17 @@ public class RequestCommands extends CommunityCommand {
   @Permission(CommunityPermissions.VIEW_MAP_COOLDOWNS)
   public void viewCooldowns(
       CommandAudience audience, Player sender, @Argument("page") @Default("1") int page) {
-    Map<MapInfo, MapCooldown> cooldowns = requests.getMapCooldowns();
+    Map<String, MapCooldown> cooldowns = requests.getMapCooldowns();
+    var library = PGM.get().getMapLibrary();
 
     List<MapInfo> maps = cooldowns.entrySet().stream()
         .filter(e -> !e.getValue().hasExpired())
-        .map(e -> e.getKey())
+        .map(e -> library.getMapById(e.getKey()))
         .collect(Collectors.toList());
 
     Comparator<MapInfo> compare = (m1, m2) -> {
-      MapCooldown m1C = cooldowns.get(m1);
-      MapCooldown m2C = cooldowns.get(m2);
+      MapCooldown m1C = cooldowns.get(m1.getId());
+      MapCooldown m2C = cooldowns.get(m2.getId());
       Instant m1D = m1C.getEndTime();
       Instant m2D = m2C.getEndTime();
 
@@ -85,7 +87,7 @@ public class RequestCommands extends CommunityCommand {
     new PaginatedComponentResults<MapInfo>(formattedTitle, resultsPerPage) {
       @Override
       public Component format(MapInfo map, int index) {
-        MapCooldown cooldown = cooldowns.get(map);
+        MapCooldown cooldown = cooldowns.get(map.getId());
 
         Component mapName = map.getStyledName(MapNameStyle.COLOR_WITH_AUTHORS)
             .clickEvent(ClickEvent.runCommand("/map " + map.getName()))

--- a/core/src/main/java/dev/pgm/community/requests/feature/RequestFeature.java
+++ b/core/src/main/java/dev/pgm/community/requests/feature/RequestFeature.java
@@ -7,6 +7,7 @@ import dev.pgm.community.requests.MapCooldown;
 import dev.pgm.community.requests.RequestProfile;
 import dev.pgm.community.requests.SponsorRequest;
 import dev.pgm.community.utils.PGMUtils.MapSizeBounds;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -168,7 +169,9 @@ public interface RequestFeature extends Feature {
 
   boolean hasMapCooldown(MapInfo map);
 
-  Map<MapInfo, MapCooldown> getMapCooldowns();
+  Duration getApproximateCooldown(MapInfo map);
+
+  Map<String, MapCooldown> getMapCooldowns();
 
   void openMenu(Player player);
 


### PR DESCRIPTION
Fixes a few things around sponsors, depends on https://github.com/PGMDev/PGM/pull/1472

Makes so cooldowns (community or pgm) will both be displayed, taking whichever has the longest effect remaining.
Also fixes cd in community being tied to the MapInfo instance, instead of simply its id.

Also makes the message for map too big/small explicitly show the maps' size, as the hover was non-obvious