### PR TITLE
Update mapcd to display full cooldowns

### DIFF
--- a/core/src/main/java/dev/pgm/community/requests/feature/RequestFeature.java
+++ b/core/src/main/java/dev/pgm/community/requests/feature/RequestFeature.java
@@ -3,7 +3,6 @@ package dev.pgm.community.requests.feature;
 import static net.kyori.adventure.text.Component.text;
 
 import dev.pgm.community.feature.Feature;
-import dev.pgm.community.requests.MapCooldown;
 import dev.pgm.community.requests.RequestProfile;
 import dev.pgm.community.requests.SponsorRequest;
 import dev.pgm.community.utils.PGMUtils.MapSizeBounds;
@@ -170,8 +169,6 @@ public interface RequestFeature extends Feature {
   boolean hasMapCooldown(MapInfo map);
 
   Duration getApproximateCooldown(MapInfo map);
-
-  Map<String, MapCooldown> getMapCooldowns();
 
   void openMenu(Player player);
 

--- a/core/src/main/java/dev/pgm/community/requests/feature/RequestFeatureBase.java
+++ b/core/src/main/java/dev/pgm/community/requests/feature/RequestFeatureBase.java
@@ -686,11 +686,6 @@ public abstract class RequestFeatureBase extends FeatureBase implements RequestF
   }
 
   @Override
-  public Map<String, MapCooldown> getMapCooldowns() {
-    return mapCooldown;
-  }
-
-  @Override
   public int getStandardExtraVoteLevel(Player player) {
     return superVotes.getVoteLevel(player);
   }

--- a/core/src/main/java/dev/pgm/community/utils/BroadcastUtils.java
+++ b/core/src/main/java/dev/pgm/community/utils/BroadcastUtils.java
@@ -27,8 +27,7 @@ public class BroadcastUtils {
   public static final Component RIGHT_DIV = text("\u00BB");
   public static final Component LEFT_DIV = text("\u00AB");
 
-  public static final Component BROADCAST_DIV =
-      text().append(space()).append(RIGHT_DIV).append(space()).build();
+  public static final Component BROADCAST_DIV = text(" \u00BB ");
 
   private static final Component ADMIN_CHAT_PREFIX = text()
       .append(text("[", NamedTextColor.WHITE))


### PR DESCRIPTION
Updates the `/mapcd` command to display cooldowns not just from community, but from pgm too, which aligns with the *real* cooldown they'll see if they try to /sponsor request the map