### PR TITLE
Fix sponsoring not considering variants

### DIFF
--- a/core/src/main/java/dev/pgm/community/requests/MapCooldown.java
+++ b/core/src/main/java/dev/pgm/community/requests/MapCooldown.java
@@ -2,26 +2,20 @@ package dev.pgm.community.requests;
 
 import java.time.Duration;
 import java.time.Instant;
+import tc.oc.pgm.util.TimeUtils;
 
 public class MapCooldown {
-  private Instant endTime;
-  private Duration matchLength;
+  private final Instant endsAt;
 
-  public MapCooldown(Instant endTime, Duration matchLength) {
-    this.endTime = endTime;
-    this.matchLength = matchLength;
-  }
-
-  public Instant getEndTime() {
-    return endTime;
+  public MapCooldown(Duration cooldown) {
+    this.endsAt = Instant.now().plus(cooldown);
   }
 
   public boolean hasExpired() {
-    return getTimeRemaining().isNegative();
+    return !getTimeRemaining().isPositive();
   }
 
   public Duration getTimeRemaining() {
-    Duration timeSince = Duration.between(endTime, Instant.now());
-    return matchLength.minus(timeSince);
+    return TimeUtils.max(Duration.ZERO, Duration.between(Instant.now(), endsAt));
   }
 }

--- a/core/src/main/java/dev/pgm/community/requests/commands/RequestCommands.java
+++ b/core/src/main/java/dev/pgm/community/requests/commands/RequestCommands.java
@@ -59,7 +59,7 @@ public class RequestCommands extends CommunityCommand {
 
     var maps = StreamUtils.of(library.getMaps())
         .map(map -> new MapWithCooldown(map, requests.getApproximateCooldown(map)))
-        .filter(mcd -> mcd.cooldown.isPositive())
+        .filter(mcd -> mcd.cooldown.toSeconds() > 0)
         .sorted(Comparator.comparing(MapWithCooldown::cooldown))
         .toList();
 

--- a/core/src/main/java/dev/pgm/community/requests/feature/RequestFeatureBase.java
+++ b/core/src/main/java/dev/pgm/community/requests/feature/RequestFeatureBase.java
@@ -75,6 +75,9 @@ import tc.oc.pgm.util.named.NameStyle;
 
 public abstract class RequestFeatureBase extends FeatureBase implements RequestFeature {
 
+  // Multiplier for minimum score to allow sponsoring
+  private static final double MIN_SCORE_MUL = 0.35;
+
   private Cache<UUID, MapInfo> requests;
 
   private Cache<UUID, Instant> cooldown;
@@ -641,7 +644,7 @@ public abstract class RequestFeatureBase extends FeatureBase implements RequestF
     return map.getVariants().values().stream()
         .map(variant -> mapLibrary.getMapById(variant.getId()))
         .filter(Objects::nonNull)
-        .map(m -> TimeUtils.max(sponsor.getSponsorCooldown(map), getPgmCooldown(map)))
+        .map(m -> TimeUtils.max(sponsor.getSponsorCooldown(m), getPgmCooldown(m)))
         .max(Comparator.naturalOrder())
         .orElse(Duration.ZERO);
   }
@@ -652,7 +655,7 @@ public abstract class RequestFeatureBase extends FeatureBase implements RequestF
     var data = pool.getVoteData(map);
     Duration cd = data.remainingCooldown(pool.constants);
     if (cd.isPositive()) return cd;
-    return data.getScore() < (pool.constants.defaultScore() / 2)
+    return data.getScore() < (pool.constants.defaultScore() * MIN_SCORE_MUL)
         ? Duration.ofMillis(1L)
         : Duration.ZERO;
   }

--- a/core/src/main/java/dev/pgm/community/requests/sponsor/SponsorManager.java
+++ b/core/src/main/java/dev/pgm/community/requests/sponsor/SponsorManager.java
@@ -17,7 +17,6 @@ import dev.pgm.community.utils.PGMUtils;
 import dev.pgm.community.utils.PGMUtils.MapSizeBounds;
 import dev.pgm.community.utils.Sounds;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -90,8 +89,7 @@ public class SponsorManager {
 
   public void startNewMapCooldown(MapInfo map, Duration matchLength) {
     this.mapCooldown.putIfAbsent(
-        map.getId(),
-        new MapCooldown(Instant.now(), matchLength.multipliedBy(config.getMapCooldownMultiply())));
+        map.getId(), new MapCooldown(matchLength.multipliedBy(config.getMapCooldownMultiply())));
   }
 
   public MapSizeBounds getCurrentMapSizeBounds() {


### PR DESCRIPTION
A few minor fixes to sponsoring
- At the moment maps don't check their variants' cooldown due to a bug, that was fixed
- Cleaned up low-term map cooldown logic
- Made /mapcd only show maps on "real" cooldown, not score-based unsponsorable
- Made minimum score to be sponsorable default * 0.35 instead of default * 0.5 (ie: /2), should be a bit less restrictive