### PR TITLE
Add option to toggle autojoin on parties

### DIFF
--- a/core/src/main/java/dev/pgm/community/history/MatchHistoryCommand.java
+++ b/core/src/main/java/dev/pgm/community/history/MatchHistoryCommand.java
@@ -2,7 +2,6 @@ package dev.pgm.community.history;
 
 import static tc.oc.pgm.util.text.TextException.exception;
 
-import co.aikar.commands.annotation.CommandPermission;
 import dev.pgm.community.Community;
 import dev.pgm.community.CommunityPermissions;
 import dev.pgm.community.utils.CommandAudience;
@@ -11,6 +10,7 @@ import tc.oc.pgm.lib.org.incendo.cloud.annotations.Command;
 import tc.oc.pgm.lib.org.incendo.cloud.annotations.CommandDescription;
 import tc.oc.pgm.lib.org.incendo.cloud.annotations.Default;
 import tc.oc.pgm.lib.org.incendo.cloud.annotations.Flag;
+import tc.oc.pgm.lib.org.incendo.cloud.annotations.Permission;
 
 @Command("matchhistory|mh")
 public class MatchHistoryCommand {
@@ -23,7 +23,7 @@ public class MatchHistoryCommand {
 
   @Command("[page]")
   @CommandDescription("Display match history")
-  @CommandPermission(CommunityPermissions.MATCH_HISTORY)
+  @Permission(CommunityPermissions.MATCH_HISTORY)
   public void sendHistory(
       CommandAudience sender,
       @Argument("page") @Default("1") int page,

--- a/core/src/main/java/dev/pgm/community/squads/Squad.java
+++ b/core/src/main/java/dev/pgm/community/squads/Squad.java
@@ -5,14 +5,14 @@ import java.util.*;
 
 public class Squad {
   private UUID leader;
-  private final Set<UUID> players;
+  private final SequencedMap<UUID, Boolean> players;
   private final Set<UUID> invites;
 
   public Squad(UUID leader) {
     this.leader = leader;
-    this.players = new LinkedHashSet<>();
+    this.players = new LinkedHashMap<>();
     this.invites = new HashSet<>();
-    players.add(leader);
+    this.players.put(leader, true);
   }
 
   public UUID getLeader() {
@@ -21,7 +21,15 @@ public class Squad {
 
   public Set<UUID> getPlayers() {
     // This is READ ONLY. to modify members use the appropriate methods
-    return Collections.unmodifiableSet(players);
+    return Collections.unmodifiableSet(players.keySet());
+  }
+
+  public boolean autojoin(UUID player) {
+    return players.getOrDefault(player, false);
+  }
+
+  public boolean toggleAutojoin(UUID player) {
+    return Boolean.TRUE.equals(players.computeIfPresent(player, (k, v) -> !v));
   }
 
   public Set<UUID> getInvites() {
@@ -36,18 +44,18 @@ public class Squad {
   public boolean removePlayer(UUID player) {
     boolean result = players.remove(player);
     if (result && Objects.equals(leader, player) && !players.isEmpty()) {
-      leader = players.iterator().next();
+      leader = players.sequencedKeySet().getFirst();
     }
     return result;
   }
 
   public boolean addPlayer(UUID player) {
     if (leader == null) leader = player;
-    return players.add(player);
+    return players.put(player, true) == null;
   }
 
   public boolean containsPlayer(UUID player) {
-    return players.contains(player);
+    return players.containsKey(player);
   }
 
   public boolean containsInvite(UUID player) {
@@ -55,7 +63,7 @@ public class Squad {
   }
 
   public boolean addInvite(UUID player) {
-    return !players.contains(player) && invites.add(player);
+    return !players.containsKey(player) && invites.add(player);
   }
 
   public boolean acceptInvite(UUID player) {

--- a/core/src/main/java/dev/pgm/community/squads/SquadCommands.java
+++ b/core/src/main/java/dev/pgm/community/squads/SquadCommands.java
@@ -37,6 +37,32 @@ import tc.oc.pgm.util.text.TextFormatter;
 @Command("party|squad|p")
 public class SquadCommands {
 
+  private static final Component LEADER_ICON = text("✦", NamedTextColor.YELLOW)
+      .hoverEvent(showText(translatable("squad.list.leader", NamedTextColor.YELLOW)));
+  private static final Component PENDING_ICON = text("➤", NamedTextColor.GOLD)
+      .hoverEvent(showText(translatable("squad.list.pending", NamedTextColor.GOLD)));
+
+  private static final ClickEvent TOGGLE_AUTOJOIN = runCommand("/party autojoin");
+  private static final Component AUTOJOIN_ENABLED = translatable(
+          "squad.autojoin",
+          NamedTextColor.YELLOW,
+          translatable("squad.autojoin.enabled", NamedTextColor.GREEN))
+      .clickEvent(TOGGLE_AUTOJOIN);
+
+  private static final Component AUTOJOIN_DISABLED = translatable(
+          "squad.autojoin",
+          NamedTextColor.YELLOW,
+          translatable("squad.autojoin.disabled", NamedTextColor.RED))
+      .clickEvent(TOGGLE_AUTOJOIN);
+
+  private static final Component AUTOJOIN_ENABLED_ICON =
+      text("▶", NamedTextColor.GREEN).hoverEvent(AUTOJOIN_ENABLED).clickEvent(TOGGLE_AUTOJOIN);
+  private static final Component AUTOJOIN_DISABLED_ICON =
+      text("■", NamedTextColor.RED).hoverEvent(AUTOJOIN_DISABLED).clickEvent(TOGGLE_AUTOJOIN);
+
+  private static final Component KICK_ICON = text("✕", NamedTextColor.DARK_RED)
+      .hoverEvent(showText(translatable("squad.list.removeHover", NamedTextColor.RED)));
+
   private final SquadFeature manager;
 
   public SquadCommands() {
@@ -125,6 +151,17 @@ public class SquadCommands {
     sender.sendMessage(translatable("squad.leave.success", NamedTextColor.YELLOW));
   }
 
+  @Command("autojoin")
+  @CommandDescription("Toggle auto-join in your current party")
+  @CommandPermission(CommunityPermissions.SQUAD)
+  public void autojoin(MatchPlayer sender) {
+    checkEnabled();
+    Squad squad = manager.getSquadByPlayer(sender);
+    if (squad == null) throw exception("squad.err.memberOnly");
+    boolean enabled = squad.toggleAutojoin(sender.getId());
+    sender.sendMessage(enabled ? AUTOJOIN_ENABLED : AUTOJOIN_DISABLED);
+  }
+
   @Command("list")
   @CommandDescription("List party members")
   @CommandPermission(CommunityPermissions.SQUAD)
@@ -159,7 +196,7 @@ public class SquadCommands {
     Squad squad = manager.getSquadByPlayer(sender);
     if (squad == null) throw exception("squad.err.memberOnly");
 
-    boolean isLeader = Objects.equals(sender.getId(), squad.getLeader());
+    boolean canKick = Objects.equals(sender.getId(), squad.getLeader());
 
     Component header = horizontalLineHeading(
         sender.getBukkit(),
@@ -172,28 +209,17 @@ public class SquadCommands {
         TextComponent.Builder builder = text()
             .append(text(index + 1))
             .append(text(". "))
-            .append(player(player, NameStyle.VERBOSE));
-        if (squad.getLeader().equals(player)) {
-          builder
-              .append(text(" "))
-              .append(
-                  translatable("squad.list.leader", NamedTextColor.GRAY, TextDecoration.ITALIC));
-        } else {
-          if (index >= squad.size()) {
-            builder
-                .append(text(" "))
-                .append(
-                    translatable("squad.list.pending", NamedTextColor.GRAY, TextDecoration.ITALIC));
-          }
-          if (isLeader) {
-            builder
-                .append(text(" "))
-                .append(text("\u2715", NamedTextColor.DARK_RED)
-                    .hoverEvent(
-                        showText(translatable("squad.list.removeHover", NamedTextColor.RED)))
-                    .clickEvent(runCommand("/party kick " + player)));
-          }
-        }
+            .append(player(player, NameStyle.VERBOSE))
+            .appendSpace();
+        boolean isLeader = squad.getLeader().equals(player);
+
+        if (index >= squad.size()) builder.append(PENDING_ICON);
+        else
+          builder.append(squad.autojoin(player) ? AUTOJOIN_ENABLED_ICON : AUTOJOIN_DISABLED_ICON);
+
+        if (isLeader) builder.appendSpace().append(LEADER_ICON);
+        else if (canKick)
+          builder.appendSpace().append(KICK_ICON.clickEvent(runCommand("/party kick " + player)));
         return builder.build();
       }
     }.display(sender, ImmutableList.copyOf(squad.getAllPlayers()), 1);

--- a/core/src/main/java/dev/pgm/community/squads/SquadCommands.java
+++ b/core/src/main/java/dev/pgm/community/squads/SquadCommands.java
@@ -8,7 +8,6 @@ import static tc.oc.pgm.util.player.PlayerComponent.player;
 import static tc.oc.pgm.util.text.TextException.exception;
 import static tc.oc.pgm.util.text.TextFormatter.horizontalLineHeading;
 
-import co.aikar.commands.annotation.CommandPermission;
 import com.google.common.collect.ImmutableList;
 import dev.pgm.community.Community;
 import dev.pgm.community.CommunityPermissions;
@@ -28,6 +27,7 @@ import tc.oc.pgm.lib.org.incendo.cloud.annotations.Argument;
 import tc.oc.pgm.lib.org.incendo.cloud.annotations.Command;
 import tc.oc.pgm.lib.org.incendo.cloud.annotations.CommandDescription;
 import tc.oc.pgm.lib.org.incendo.cloud.annotations.Flag;
+import tc.oc.pgm.lib.org.incendo.cloud.annotations.Permission;
 import tc.oc.pgm.lib.org.incendo.cloud.context.CommandContext;
 import tc.oc.pgm.util.Players;
 import tc.oc.pgm.util.PrettyPaginatedComponentResults;
@@ -71,7 +71,7 @@ public class SquadCommands {
 
   @Command("")
   @CommandDescription("List party members")
-  @CommandPermission(CommunityPermissions.SQUAD)
+  @Permission(CommunityPermissions.SQUAD)
   public void listDefault(MatchPlayer sender) {
     checkEnabled();
     list(sender, false);
@@ -79,7 +79,7 @@ public class SquadCommands {
 
   @Command("<player>")
   @CommandDescription("Send a squad invitation")
-  @CommandPermission(CommunityPermissions.SQUAD_CREATE)
+  @Permission(CommunityPermissions.SQUAD_CREATE)
   public void directInvite(MatchPlayer sender, @Argument("player") MatchPlayer invited) {
     checkEnabled();
     invite(sender, invited);
@@ -87,7 +87,7 @@ public class SquadCommands {
 
   @Command("create")
   @CommandDescription("Create a squad")
-  @CommandPermission(CommunityPermissions.SQUAD_CREATE)
+  @Permission(CommunityPermissions.SQUAD_CREATE)
   public void create(MatchPlayer sender) {
     checkEnabled();
     manager.createSquad(sender);
@@ -96,7 +96,7 @@ public class SquadCommands {
 
   @Command("invite <player>")
   @CommandDescription("Send a squad invitation")
-  @CommandPermission(CommunityPermissions.SQUAD_CREATE)
+  @Permission(CommunityPermissions.SQUAD_CREATE)
   public void invite(MatchPlayer sender, @Argument("player") MatchPlayer invited) {
     checkEnabled();
     manager.createInvite(invited, sender);
@@ -118,7 +118,7 @@ public class SquadCommands {
 
   @Command("accept <player>")
   @CommandDescription("Accept a squad invitation")
-  @CommandPermission(CommunityPermissions.SQUAD)
+  @Permission(CommunityPermissions.SQUAD)
   public void accept(MatchPlayer sender, @Argument("player") MatchPlayer leader) {
     checkEnabled();
     manager.acceptInvite(sender, leader);
@@ -131,7 +131,7 @@ public class SquadCommands {
 
   @Command("deny <player>")
   @CommandDescription("Deny a squad invitation")
-  @CommandPermission(CommunityPermissions.SQUAD)
+  @Permission(CommunityPermissions.SQUAD)
   public void deny(MatchPlayer sender, @Argument("player") MatchPlayer leader) {
     checkEnabled();
     manager.expireInvite(sender, leader);
@@ -144,7 +144,7 @@ public class SquadCommands {
 
   @Command("leave")
   @CommandDescription("Leave your current party")
-  @CommandPermission(CommunityPermissions.SQUAD)
+  @Permission(CommunityPermissions.SQUAD)
   public void leave(MatchPlayer sender) {
     checkEnabled();
     manager.leaveSquad(sender);
@@ -153,7 +153,7 @@ public class SquadCommands {
 
   @Command("autojoin")
   @CommandDescription("Toggle auto-join in your current party")
-  @CommandPermission(CommunityPermissions.SQUAD)
+  @Permission(CommunityPermissions.SQUAD)
   public void autojoin(MatchPlayer sender) {
     checkEnabled();
     Squad squad = manager.getSquadByPlayer(sender);
@@ -164,7 +164,7 @@ public class SquadCommands {
 
   @Command("list")
   @CommandDescription("List party members")
-  @CommandPermission(CommunityPermissions.SQUAD)
+  @Permission(CommunityPermissions.SQUAD)
   public void list(MatchPlayer sender, @Flag(value = "all", aliases = "a") boolean all) {
     checkEnabled();
 
@@ -227,7 +227,7 @@ public class SquadCommands {
 
   @Command("chat [message]")
   @CommandDescription("Sends a message to your party")
-  @CommandPermission(CommunityPermissions.SQUAD)
+  @Permission(CommunityPermissions.SQUAD)
   public void chat(
       CommandContext<CommandSender> context,
       MatchPlayer sender,
@@ -242,7 +242,7 @@ public class SquadCommands {
 
   @Command("kick <player>")
   @CommandDescription("Kick a player from your party")
-  @CommandPermission(CommunityPermissions.SQUAD)
+  @Permission(CommunityPermissions.SQUAD)
   public void kick(MatchPlayer sender, @Argument("player") OfflinePlayer player) {
     checkEnabled();
     MatchPlayer target = PGM.get().getMatchManager().getPlayer(player.getUniqueId());
@@ -257,7 +257,7 @@ public class SquadCommands {
 
   @Command("disband")
   @CommandDescription("Disband your current party")
-  @CommandPermission(CommunityPermissions.SQUAD)
+  @Permission(CommunityPermissions.SQUAD)
   public void disband(MatchPlayer sender) {
     checkEnabled();
     manager.disband(sender);

--- a/core/src/main/java/dev/pgm/community/squads/SquadFeature.java
+++ b/core/src/main/java/dev/pgm/community/squads/SquadFeature.java
@@ -2,27 +2,29 @@ package dev.pgm.community.squads;
 
 import static dev.pgm.community.utils.PGMUtils.isPGMEnabled;
 import static net.kyori.adventure.text.Component.text;
+import static net.kyori.adventure.text.Component.translatable;
 import static tc.oc.pgm.util.player.PlayerComponent.player;
 import static tc.oc.pgm.util.text.TextException.exception;
 import static tc.oc.pgm.util.text.TextException.noPermission;
 
 import dev.pgm.community.CommunityPermissions;
 import dev.pgm.community.feature.FeatureBase;
-import dev.pgm.community.utils.AFKDetection;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 import org.bukkit.configuration.Configuration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -35,22 +37,23 @@ import tc.oc.pgm.api.integration.Integration;
 import tc.oc.pgm.api.integration.SquadIntegration;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.event.MatchAfterLoadEvent;
+import tc.oc.pgm.api.match.event.MatchLoadEvent;
 import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.events.PlayerParticipationStartEvent;
 import tc.oc.pgm.join.JoinMatchModule;
 import tc.oc.pgm.join.JoinRequest;
 import tc.oc.pgm.join.JoinResult;
-import tc.oc.pgm.teams.Team;
 import tc.oc.pgm.teams.TeamMatchModule;
 import tc.oc.pgm.util.named.NameStyle;
 
 public class SquadFeature extends FeatureBase implements SquadIntegration {
 
-  private final List<Squad> squads = new ArrayList<>();
-
-  private final Map<UUID, ScheduledFuture<?>> playerLeave = new HashMap<>();
-
+  private final Duration AFK_TIME = Duration.ofSeconds(120);
   private final ScheduledExecutorService executor = PGM.get().getExecutor();
-  private final AFKDetection afk = new AFKDetection();
+
+  private final List<Squad> squads = new ArrayList<>();
+  private final Map<UUID, ScheduledFuture<?>> playerLeave = new HashMap<>();
+  private final Set<UUID> preventJoins = new HashSet<>();
 
   public SquadFeature(Configuration config, Logger logger) {
     super(new SquadConfig(config), logger, "Squads (PGM)");
@@ -220,35 +223,47 @@ public class SquadFeature extends FeatureBase implements SquadIntegration {
   }
 
   @EventHandler
-  public void onPlayerJoinMatch(MatchAfterLoadEvent event) {
+  public void onMatchLoad(MatchLoadEvent event) {
+    this.squads.forEach(s -> preventJoins.addAll(s.getPlayers()));
+  }
+
+  @EventHandler
+  public void onPlayerJoinTeam(PlayerParticipationStartEvent event) {
+    if (preventJoins.contains(event.getPlayer().getId()))
+      event.cancel(text("squad.warn.manualJoin"));
+  }
+
+  @EventHandler
+  public void onAfterMatchLoad(MatchAfterLoadEvent event) {
+    this.preventJoins.clear();
     JoinMatchModule jmm = event.getMatch().needModule(JoinMatchModule.class);
-    squads.stream().sorted(Comparator.comparingInt(s -> -s.size())).forEach(s -> {
-      List<MatchPlayer> players = s.getPlayers().stream()
-          .map(uuid -> event.getMatch().getPlayer(uuid))
-          .filter(Objects::nonNull)
-          .filter(mp -> !afk.isAFK(mp.getBukkit()))
-          .collect(Collectors.toList());
-      if (players.isEmpty()) return;
-      MatchPlayer leader = event.getMatch().getPlayer(s.getLeader());
-      if (leader == null) leader = players.get(0);
+    squads.stream()
+        .map(s -> s.getPlayers().stream()
+            .map(uuid -> event.getMatch().getPlayer(uuid))
+            .filter(mp -> {
+              if (mp == null) return false;
+              boolean j = s.autojoin(mp.getId());
+              if (!j) mp.sendWarning(translatable("squad.warn.autoJoin"));
+              if (j && !(j = mp.isActive(AFK_TIME))) mp.sendWarning(translatable("squad.warn.afk"));
+              return j;
+            })
+            .toList())
+        .filter(l -> !l.isEmpty())
+        .sorted(Comparator.comparingInt(s -> -s.size()))
+        .forEach(players -> {
+          MatchPlayer leader = players.getFirst();
+          EnumSet<JoinRequest.Flag> flags = JoinRequest.playerFlags(leader, JoinRequest.Flag.SQUAD);
 
-      EnumSet<JoinRequest.Flag> flags = JoinRequest.playerFlags(leader, JoinRequest.Flag.SQUAD);
+          JoinRequest request = JoinRequest.group(null, players.size(), flags);
+          JoinResult result = jmm.queryJoin(leader, request);
 
-      JoinRequest request = JoinRequest.group(null, players.size(), flags);
-      JoinResult result = jmm.queryJoin(leader, request);
-
-      // If a team is picked, re-build the request to include it. This will prevent pgm from
-      // assuming it's able to re-balance the squad to a diff team.
-      final JoinRequest finalRequest;
-      if (result instanceof TeamMatchModule.TeamJoinResult) {
-        Team team = ((TeamMatchModule.TeamJoinResult) result).getTeam();
-        finalRequest = JoinRequest.group(team, players.size(), flags);
-      } else {
-        finalRequest = request;
-      }
-
-      players.forEach(p -> jmm.join(p, finalRequest, result));
-    });
+          // If a team is picked, re-build the request to include it. This will prevent pgm from
+          // assuming it's able to re-balance the squad to a diff team.
+          JoinRequest finalRequest = result instanceof TeamMatchModule.TeamJoinResult tjr
+              ? JoinRequest.group(tjr.getTeam(), players.size(), flags)
+              : request;
+          players.forEach(p -> jmm.join(p, finalRequest, result));
+        });
   }
 
   private int getMaxSquadSize(MatchPlayer leader) {

--- a/core/src/main/resources/strings.properties
+++ b/core/src/main/resources/strings.properties
@@ -13,10 +13,14 @@ squad.deny.leader = {0} has denied your invitation
 
 squad.leave.success = Successfully left the party
 
+squad.autojoin = Auto join: {0} (click to toggle)
+squad.autojoin.enabled = ENABLED
+squad.autojoin.disabled = DISABLED
+
 squad.list.all = Parties
 squad.list.header = {0}'s Party
-squad.list.leader = (leader)
-squad.list.pending = (pending)
+squad.list.leader = Party leader
+squad.list.pending = Pending invite
 squad.list.removeHover = Remove player from party
 
 squad.kicked.leader = Kicked {0} from your party
@@ -34,3 +38,7 @@ squad.err.memberOnly = You are not in a party
 squad.err.notInYourParty = {0} is not in your party
 squad.err.leaderCannotLeave = You cannot leave your own party (you must disband it instead)
 squad.err.notEnabled = This feature is not enabled
+
+squad.warn.autoJoin = Skipped party auto join since you disabled it
+squad.warn.afk = Skipped party auto join because you were AFK
+squad.warn.manualJoin = Manual join was prevented as it messes with party auto join


### PR DESCRIPTION
Allows you to `/party autojoin` to toggle autojoining, also has controls for it within `/party list`.

Party list was also visually revamped and now uses icons with hovers to signify party leader and pending invites, as well as displaying the autojoin status.

![image](https://github.com/user-attachments/assets/9a2c66d2-fd19-4be9-9c78-ea5d3123db94)
Pablete1234: autojoin enabled & leader
TTtie: autojoin disabled & button to kick, only visible to leader