### PR TITLE
Make squads auto-create/disband, fix minor issues

### DIFF
--- a/core/src/main/java/dev/pgm/community/squads/Squad.java
+++ b/core/src/main/java/dev/pgm/community/squads/Squad.java
@@ -2,9 +2,15 @@ package dev.pgm.community.squads;
 
 import com.google.common.collect.Iterables;
 import java.util.*;
+import java.util.stream.Stream;
+import org.jetbrains.annotations.NotNull;
+import tc.oc.pgm.api.PGM;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.util.Audience;
 
-public class Squad {
+public class Squad implements Audience {
   private UUID leader;
+  private final Audience audience;
   private final SequencedMap<UUID, Boolean> players;
   private final Set<UUID> invites;
 
@@ -13,6 +19,8 @@ public class Squad {
     this.players = new LinkedHashMap<>();
     this.invites = new HashSet<>();
     this.players.put(leader, true);
+    this.audience =
+        Audience.get((Iterable<MatchPlayer>) () -> this.getMatchPlayers().iterator());
   }
 
   public UUID getLeader() {
@@ -20,8 +28,18 @@ public class Squad {
   }
 
   public Set<UUID> getPlayers() {
-    // This is READ ONLY. to modify members use the appropriate methods
+    // This is READ-ONLY. To modify members use the appropriate methods
     return Collections.unmodifiableSet(players.keySet());
+  }
+
+  @Override
+  public net.kyori.adventure.audience.@NotNull Audience audience() {
+    return audience;
+  }
+
+  public Stream<MatchPlayer> getMatchPlayers() {
+    var mm = PGM.get().getMatchManager();
+    return players.keySet().stream().map(mm::getPlayer).filter(Objects::nonNull);
   }
 
   public boolean autojoin(UUID player) {
@@ -37,7 +55,7 @@ public class Squad {
   }
 
   public Iterable<UUID> getAllPlayers() {
-    // This is READ ONLY. to modify members use the appropriate methods
+    // This is READ-ONLY. To modify members use the appropriate methods
     return Iterables.concat(getPlayers(), getInvites());
   }
 

--- a/core/src/main/java/dev/pgm/community/squads/SquadChannel.java
+++ b/core/src/main/java/dev/pgm/community/squads/SquadChannel.java
@@ -6,15 +6,12 @@ import static tc.oc.pgm.util.text.TextException.exception;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.Nullable;
-import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.channels.Channel;
-import tc.oc.pgm.api.match.MatchManager;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.lib.org.incendo.cloud.context.CommandContext;
 import tc.oc.pgm.util.named.NameStyle;
@@ -29,11 +26,9 @@ public class SquadChannel implements Channel<Squad> {
       text().append(text("(Party) ", NamedTextColor.YELLOW)).build();
 
   private SquadFeature squads;
-  private MatchManager matchManager;
 
   public void init(SquadFeature squadFeature) {
     this.squads = squadFeature;
-    this.matchManager = PGM.get().getMatchManager();
   }
 
   @Override
@@ -61,10 +56,7 @@ public class SquadChannel implements Channel<Squad> {
 
   @Override
   public Collection<MatchPlayer> getViewers(Squad squad) {
-    return squad.getPlayers().stream()
-        .filter(Objects::nonNull)
-        .map(uuid -> matchManager.getPlayer(uuid))
-        .toList();
+    return squad.getMatchPlayers().toList();
   }
 
   @Override

--- a/core/src/main/java/dev/pgm/community/squads/SquadCommands.java
+++ b/core/src/main/java/dev/pgm/community/squads/SquadCommands.java
@@ -85,15 +85,6 @@ public class SquadCommands {
     invite(sender, invited);
   }
 
-  @Command("create")
-  @CommandDescription("Create a squad")
-  @Permission(CommunityPermissions.SQUAD_CREATE)
-  public void create(MatchPlayer sender) {
-    checkEnabled();
-    manager.createSquad(sender);
-    sender.sendMessage(translatable("squad.create.success", NamedTextColor.YELLOW));
-  }
-
   @Command("invite <player>")
   @CommandDescription("Send a squad invitation")
   @Permission(CommunityPermissions.SQUAD_CREATE)

--- a/core/src/main/java/dev/pgm/community/squads/SquadFeature.java
+++ b/core/src/main/java/dev/pgm/community/squads/SquadFeature.java
@@ -117,7 +117,10 @@ public class SquadFeature extends FeatureBase implements SquadIntegration {
   }
 
   private void updateSquad(@Nullable MatchPlayer player, Squad squad) {
-    if (squad.isEmpty()) squads.remove(squad);
+    // Auto-disband solo squads with no invites
+    if (squad.totalSize() <= 1 && squads.remove(squad)) {
+      squad.sendWarning(translatable("squad.disband.empty"));
+    }
     if (player != null) {
       Match match = player.getMatch();
       boolean isPresent = false;
@@ -146,7 +149,11 @@ public class SquadFeature extends FeatureBase implements SquadIntegration {
   public void leaveSquad(MatchPlayer player) {
     Squad squad = getSquadByPlayer(player);
     if (squad == null) throw exception("squad.err.memberOnly");
-    if (squad.getLeader().equals(player.getId())) throw exception("squad.err.leaderCannotLeave");
+    if (squad.getLeader().equals(player.getId())) {
+      if (squad.size() > 2) throw exception("squad.err.leaderCannotLeave");
+      disband(player);
+      return;
+    }
     leaveSquad(player, player.getId(), squad);
   }
 
@@ -177,11 +184,11 @@ public class SquadFeature extends FeatureBase implements SquadIntegration {
 
   /** Invite command handlers * */
   public void createInvite(MatchPlayer invited, MatchPlayer leader) {
-    Squad squad = getOrCreateSquadByLeader(leader);
-
+    if (leader.getId().equals(invited.getId())) throw exception("squad.err.noSelfInvite");
     if (getSquadByPlayer(invited) != null)
       throw exception("squad.err.alreadyInSquad", invited.getName(NameStyle.VERBOSE));
 
+    Squad squad = getOrCreateSquadByLeader(leader);
     int maxSize = getMaxSquadSize(leader);
     if (maxSize <= 0) throw noPermission();
     if (squad.totalSize() >= maxSize)
@@ -230,7 +237,7 @@ public class SquadFeature extends FeatureBase implements SquadIntegration {
   @EventHandler
   public void onPlayerJoinTeam(PlayerParticipationStartEvent event) {
     if (preventJoins.contains(event.getPlayer().getId()))
-      event.cancel(text("squad.warn.manualJoin"));
+      event.cancel(translatable("squad.warn.manualJoin"));
   }
 
   @EventHandler

--- a/core/src/main/resources/strings.properties
+++ b/core/src/main/resources/strings.properties
@@ -27,6 +27,7 @@ squad.kicked.leader = Kicked {0} from your party
 squad.kicked.player = You were kicked from {0}'s party
 
 squad.disband.success = You have successfully disbanded your party
+squad.disband.empty = Your party disbanded since all players left
 
 squad.err.alreadyInvited = {0} is already in your squad or has a pending invite
 squad.err.alreadyCreated = You're already in a party
@@ -34,8 +35,9 @@ squad.err.alreadyInSquad = {0} is already in a party
 squad.err.noInvite = No pending invite from {0} was found
 squad.err.full = Party is already full or has pending invites ({0}/{1} players)
 squad.err.leaderOnly = You must be the party leader to perform this command
-squad.err.memberOnly = You are not in a party
+squad.err.memberOnly = You are not in a party. Start one with /party <player>
 squad.err.notInYourParty = {0} is not in your party
+squad.err.noSelfInvite = You can't invite yourself to a party
 squad.err.leaderCannotLeave = You cannot leave your own party (you must disband it instead)
 squad.err.notEnabled = This feature is not enabled
 


### PR DESCRIPTION
Fixes an issue with a missing translation for squads, on top of that makes it so there's no `/party create` anymore, instead parties are automatically created when you invite a player, and automatically disbanded when they're down to a single player left. 

Also makes it so a leader can /party leave as long as they're down to just 2 players instead of forcing them to /party disband, as the effect is the same; they'd leave, a single player would be left alone, and party would disband.

Ontop of that, it makes party implement audience, only a message is sent for auto-disbanding but maybe in the future we can expand the feedback, ie: tell party members when players are added/removed from the party etc