### PR TITLE
Add fixes to map sponsoring

### DIFF
--- a/core/src/main/java/dev/pgm/community/requests/RequestConfig.java
+++ b/core/src/main/java/dev/pgm/community/requests/RequestConfig.java
@@ -22,6 +22,7 @@ public class RequestConfig extends FeatureConfigImpl {
   private static final String WEEKLY_TOKENS = SPONSORS + ".weekly-tokens";
   private static final String MAX_TOKENS = SPONSORS + ".max-tokens";
   private static final String REFUND = SPONSORS + ".refund";
+  private static final String MAP_COOLDOWN_MIN = SPONSORS + ".map-cooldown-min";
   private static final String MAP_COOLDOWN_MULTIPLY = SPONSORS + ".map-cooldown";
   private static final String USE_PGM_COOLDOWNS = SPONSORS + ".use-pgm-cooldowns";
   private static final String SCALE_FACTOR = SPONSORS + ".scale-factor";
@@ -47,9 +48,9 @@ public class RequestConfig extends FeatureConfigImpl {
 
   private boolean refund; // If token should be refunded when vote is successful
 
+  private Duration mapCooldownMin; // Minimum cooldown after a map is sponsored
   private int mapCooldownMultiply; // # to multiply match length by to determine cooldown
-  private boolean
-      usePGMCooldowns; // Whether to use PGM's map cooldown storage for additional lookup
+  private boolean usePGMCooldowns; // Whether to also use PGM's map cooldown storage
 
   private double scaleFactor; // Scaling factor for adjusting the upper bound of map size selection
 
@@ -107,6 +108,10 @@ public class RequestConfig extends FeatureConfigImpl {
     return refund;
   }
 
+  public Duration getMapCooldownMin() {
+    return mapCooldownMin;
+  }
+
   public int getMapCooldownMultiply() {
     return mapCooldownMultiply;
   }
@@ -150,6 +155,7 @@ public class RequestConfig extends FeatureConfigImpl {
     this.maxTokens = config.getInt(MAX_TOKENS);
     this.maxQueue = config.getInt(SPONSORS_LIMIT);
     this.refund = config.getBoolean(REFUND);
+    this.mapCooldownMin = parseDuration(config.getString(MAP_COOLDOWN_MIN, "30m"));
     this.mapCooldownMultiply = config.getInt(MAP_COOLDOWN_MULTIPLY);
     this.usePGMCooldowns = config.getBoolean(USE_PGM_COOLDOWNS);
     this.scaleFactor = config.getDouble(SCALE_FACTOR);

--- a/core/src/main/java/dev/pgm/community/requests/feature/RequestFeatureBase.java
+++ b/core/src/main/java/dev/pgm/community/requests/feature/RequestFeatureBase.java
@@ -134,8 +134,8 @@ public abstract class RequestFeatureBase extends FeatureBase implements RequestF
     // Cooldown
     if (hasCooldown(player, viewer)) return;
 
-    if (requests.getIfPresent(player.getUniqueId()) != null) {
-      MapInfo oldMap = requests.getIfPresent(player.getUniqueId());
+    MapInfo oldMap;
+    if ((oldMap = requests.getIfPresent(player.getUniqueId())) != null) {
 
       // Same map error
       if (map.equals(oldMap)) {
@@ -330,7 +330,7 @@ public abstract class RequestFeatureBase extends FeatureBase implements RequestF
     });
   }
 
-  @EventHandler
+  @EventHandler(priority = EventPriority.MONITOR)
   public void onMatchEnd(MatchFinishEvent event) {
     superVotes.onVoteStart();
 
@@ -340,36 +340,48 @@ public abstract class RequestFeatureBase extends FeatureBase implements RequestF
 
     // Add cooldown for existing map and all variants
     sponsor.startNewMapCooldown(event.getMatch().getMap(), event.getMatch().getDuration());
+    if (sponsor.getSponsorQueue().isEmpty()) return;
 
     MapPoolManager poolManager = getPoolManager();
     if (poolManager == null) return; // Cancel if pool manager not found
 
-    VotePoolOptions options = poolManager.getVoteOptions();
+    // Schedule the actual sponsoring for slightly after match end
+    // This ensures if a restart, party start, or other sponsor-altering event is queued, it will
+    // prevent
+    PGM.get()
+        .getExecutor()
+        .schedule(
+            () -> {
+              VotePoolOptions options = poolManager.getVoteOptions();
 
-    if (sponsor.getSponsorQueue().isEmpty()) return;
-    if (!options.canAddMap()) return;
-    if (poolManager.getOverriderMap() != null) return;
-    if (isBlitz()) return; // Prevent sponsor after blitz map
+              if (!options.getCustomVoteMaps().isEmpty()) return; // Already some vote-added map(s)
+              if (poolManager.getOverriderMap() != null) return; // Set-nexted map
+              if (isBlitz()) return; // Prevent sponsor after blitz map
+              if (RestartManager.isQueued()) return; // No sponsor when restarting
+              if (isPartyActive()) return; // No sponsor during parties
 
-    SponsorRequest nextRequest = sponsor.getNextSponsor();
+              SponsorRequest nextRequest = sponsor.getNextSponsor();
 
-    if (nextRequest != null) {
-      // Notify PGM of sponsored map
-      options.addMap(nextRequest.getMap(), nextRequest.getPlayerId());
+              if (nextRequest == null) return;
+              // Notify PGM of the sponsored map and minimum cooldown
+              options.addMap(nextRequest.getMap(), nextRequest.getPlayerId());
+              sponsor.startNewMapCooldown(nextRequest.getMap(), Duration.ZERO);
 
-      // Track the current sponsor
-      sponsor.setCurrentSponsor(nextRequest);
+              // Track the current sponsor
+              sponsor.setCurrentSponsor(nextRequest);
 
-      // Update profile
-      getRequestProfile(nextRequest.getPlayerId()).thenAcceptAsync(profile -> {
-        // Update RequestProfile with sponsor map info
-        profile.sponsor(nextRequest.getMap());
-        update(profile);
-      });
+              // Update profile
+              getRequestProfile(nextRequest.getPlayerId()).thenAcceptAsync(profile -> {
+                // Update RequestProfile with sponsor map info
+                profile.sponsor(nextRequest.getMap());
+                update(profile);
+              });
 
-      // Alert online player if their sponsor request has been processed
-      sponsor.alertRequesterToConfirmation(nextRequest.getPlayerId());
-    }
+              // Alert online player if their sponsor request has been processed
+              sponsor.alertRequesterToConfirmation(nextRequest.getPlayerId());
+            },
+            1,
+            TimeUnit.SECONDS);
   }
 
   @EventHandler

--- a/core/src/main/java/dev/pgm/community/requests/sponsor/SponsorManager.java
+++ b/core/src/main/java/dev/pgm/community/requests/sponsor/SponsorManager.java
@@ -17,10 +17,10 @@ import dev.pgm.community.utils.PGMUtils;
 import dev.pgm.community.utils.PGMUtils.MapSizeBounds;
 import dev.pgm.community.utils.Sounds;
 import java.time.Duration;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -31,6 +31,7 @@ import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.map.MapInfo;
 import tc.oc.pgm.api.map.Phase;
 import tc.oc.pgm.util.Audience;
+import tc.oc.pgm.util.TimeUtils;
 import tc.oc.pgm.util.named.MapNameStyle;
 
 public class SponsorManager {
@@ -40,7 +41,7 @@ public class SponsorManager {
 
   private final Map<String, MapCooldown> mapCooldown;
 
-  private LinkedList<SponsorRequest> sponsors;
+  private final LinkedList<SponsorRequest> sponsors;
 
   private SponsorRequest currentSponsor;
 
@@ -80,7 +81,7 @@ public class SponsorManager {
     var cd = mapCooldown.get(map.getId());
     if (cd == null) return Duration.ZERO;
     var remaining = cd.getTimeRemaining();
-    if (remaining.isNegative()) {
+    if (!remaining.isPositive()) {
       mapCooldown.remove(map.getId());
       return Duration.ZERO;
     }
@@ -88,8 +89,11 @@ public class SponsorManager {
   }
 
   public void startNewMapCooldown(MapInfo map, Duration matchLength) {
-    this.mapCooldown.putIfAbsent(
-        map.getId(), new MapCooldown(matchLength.multipliedBy(config.getMapCooldownMultiply())));
+    this.mapCooldown.compute(map.getId(), (k, currCd) -> {
+      Duration newWait = matchLength.multipliedBy(config.getMapCooldownMultiply());
+      if (currCd != null) newWait = newWait.plus(currCd.getTimeRemaining());
+      return new MapCooldown(TimeUtils.max(config.getMapCooldownMin(), newWait));
+    });
   }
 
   public MapSizeBounds getCurrentMapSizeBounds() {
@@ -98,25 +102,16 @@ public class SponsorManager {
   }
 
   public SponsorRequest getNextSponsor() {
-    Queue<SponsorRequest> requests = new LinkedList<>();
-    SponsorRequest validRequest = null;
-
-    while (!sponsors.isEmpty()) {
-      SponsorRequest request = sponsors.poll();
-      if (isMapSizeAllowed(request.getMap())) {
-        validRequest = request;
-        break;
-      } else {
-        requests.offer(request);
+    for (Iterator<SponsorRequest> it = sponsors.iterator(); it.hasNext(); ) {
+      SponsorRequest request = it.next();
+      if (!isMapSizeAllowed(request.getMap())) {
         sendWrongSizeMapError(request);
+        continue;
       }
+      it.remove();
+      return request;
     }
-
-    while (!requests.isEmpty()) {
-      sponsors.offer(requests.poll());
-    }
-
-    return validRequest;
+    return null;
   }
 
   public void queueSponsorRequest(Player player, MapInfo map) {
@@ -136,8 +131,7 @@ public class SponsorManager {
 
     // Check permission to determine what amount to refresh
     // Always prefer the daily compared to the weekly (e.g sponsor inherits donor
-    // perms,
-    // only give daily not weekly)
+    // perms, only give daily not weekly)
     if (player.hasPermission(CommunityPermissions.TOKEN_DAILY)) {
       if (profile.hasDayElapsed()) {
         refresh = config.getDailyTokenAmount();

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -230,6 +230,7 @@ requests:
   sponsors: 
     enabled: true           # Whether /sponsor is enabled
     cooldown: "30m"         # Duration of cooldown between /sponsor requests
+    map-cooldown-min: 30m   # Minimum map cooldown after it is sponsored
     map-cooldown: 10        # How much to multiply match duration by for map cooldown
     use-pgm-cooldowns: true # Whether to hook into PGMs persistent map cooldown storage
     limit: 10               # Maximum number of sponsor requests allowed at one time


### PR DESCRIPTION
Fixes a bunch of things for map sponsoring:

- Adds a minimum map cooldown after sponsoring
- Applies that minimum map cooldown when it's sponsored; even if it loses the vote
- Fixed map cooldowns never expiring, and being left as 0 forever (as they're never negative, they were never removed)
- Fixed map dooldowns not overriding a previous cooldown (eg: prior could be 0, and never overridden), now instead they'll get summed
- Map will be actually sponsored a second after match end, to avoid sponsoring and losing your token (eg: server restart)
- Ensured sponsors don't go thru if:
  - an event started (avoids your sponsor going against other party maps, effectively losing it)
  - another map is added to the vote (again, avoids your sponsor going against another added map)
  - a restart is queued, as you'd lose the token
