### PR TITLE
fix: re-add filtering by map name to `/sponsor maps`

### DIFF
--- a/core/src/main/java/dev/pgm/community/requests/commands/sponsor/SponsorCommands.java
+++ b/core/src/main/java/dev/pgm/community/requests/commands/sponsor/SponsorCommands.java
@@ -206,6 +206,11 @@ public class SponsorCommands extends CommunityCommand {
       @Flag(value = "name", aliases = "n") String name) {
     Stream<MapInfo> search = requests.getAvailableSponsorMaps().stream();
 
+    if (name != null) {
+      String query = StringUtils.normalize(name);
+      search = search.filter(map -> LiquidMetal.match(map.getNormalizedName(), query));
+    }
+
     if (!tags.isEmpty()) {
       final Map<Boolean, Set<String>> tagSet = tags.stream()
           .flatMap(t -> Arrays.stream(t.split(",")))

--- a/core/src/main/java/dev/pgm/community/requests/sponsor/SponsorManager.java
+++ b/core/src/main/java/dev/pgm/community/requests/sponsor/SponsorManager.java
@@ -173,7 +173,9 @@ public class SponsorManager {
   }
 
   public List<MapInfo> getAvailableSponsorMaps() {
-    return Lists.newArrayList(PGM.get().getMapLibrary().getMaps()).stream()
+    return PGM.get()
+        .getMapLibrary()
+        .getMaps(/* query */ null)
         .filter(this::isMapSizeAllowed)
         .filter(m -> m.getPhase() == Phase.PRODUCTION)
         .filter(m -> !requests.hasMapCooldown(m))


### PR DESCRIPTION
Re-adds name filtering to `/sponsor maps`, which was (probably unintentionally) removed by b6bad75ce0593e1d0afd5bcd65bcf0d0f64da25d. Search implementation was copied over from [`MapLibrary#getMaps(String)`](<https://github.com/PGMDev/PGM/blob/7912dc6d9804dc9550d52347296a34801fadc319/core/src/main/java/tc/oc/pgm/map/MapLibraryImpl.java#L72>) in PGM.

Additionally, `SponsorManager#getAvailableSponsorMaps()` has been changed to use `MapLibrary#getMaps(String)` instead of the zero-arity method to avoid stream copies. (Maybe the search query could be passed down to PGM instead of manually filtering it afterwards?)