### PR TITLE
Update event time limit messages

### DIFF
--- a/core/src/main/java/dev/pgm/community/party/MapPartyMessages.java
+++ b/core/src/main/java/dev/pgm/community/party/MapPartyMessages.java
@@ -120,7 +120,7 @@ public class MapPartyMessages {
   }
 
   public static String formatTime(MapParty party) {
-    if (party.getLength() == null) return ChatColor.YELLOW + "No timelimit";
+    if (party.getLength() == null) return ChatColor.YELLOW + "No time limit";
     String duration = TextTranslations.translateLegacy(duration(party.getLength()));
 
     if (party.getStartTime() == null) return ChatColor.GOLD + duration;

--- a/core/src/main/java/dev/pgm/community/party/feature/MapPartyFeature.java
+++ b/core/src/main/java/dev/pgm/community/party/feature/MapPartyFeature.java
@@ -322,19 +322,18 @@ public class MapPartyFeature extends FeatureBase {
     party.setLength(timeLimit);
     MapPartyMessages.broadcastHostAction(
         viewer.getStyledName(),
-        text("set the event timelimit to"),
+        text("set the event time limit to"),
         duration(party.getLength(), NamedTextColor.GREEN));
     if (party.isRunning()) {
-      MapPartyMessages.broadcastHostAction(
-          viewer.getStyledName(),
+      BroadcastUtils.sendAdminChatMessage(
           text()
               .append(text("The event will now end in "))
               .append(
                   duration(timeLimit.minus(Duration.between(party.getStartTime(), Instant.now())))
                       .color(NamedTextColor.GREEN))
               .color(NamedTextColor.GRAY)
-              .build());
-      ;
+              .build(),
+          CommunityPermissions.PARTY);
     }
   }
 


### PR DESCRIPTION
Updates messages for event time host commands - one of them currently has the player name in a weird spot, as broadcastHostMessage requires it. It also shows two messages when updating the time limit, and uses "timelimit" instead of "time limit", which is how it appears in other places. 

Before:
<img width="478" height="38" alt="image" src="https://github.com/user-attachments/assets/440b6e41-a351-4774-a4d2-820540f7c035" />
Note the name before "The".

After:
<img width="631" height="39" alt="image" src="https://github.com/user-attachments/assets/e6944dac-07c8-4a97-bef1-82f3fc36d374" />