### PR TITLE
Post Friendship update to main thread

### DIFF
--- a/core/src/main/java/dev/pgm/community/friends/feature/types/FriendshipFeatureCore.java
+++ b/core/src/main/java/dev/pgm/community/friends/feature/types/FriendshipFeatureCore.java
@@ -196,8 +196,10 @@ public class FriendshipFeatureCore extends FeatureBase implements FriendshipFeat
           friends.stream().map(f -> f.getOtherPlayer(playerId)).collect(Collectors.toSet());
       // Sends updated friendship status to PGM for hook-in
       if (integration != null) {
-        integration.setFriends(playerId, friendIds);
-        integration.callUpdateEvents(playerId, friendIds);
+        Bukkit.getScheduler().runTask(Community.get(), () -> {
+          integration.setFriends(playerId, friendIds);
+          integration.callUpdateEvents(playerId, friendIds);
+        });
       }
     });
   }


### PR DESCRIPTION
Should fix the following bug:

```java
 java.util.ConcurrentModificationException
 	at java.base/java.util.ArrayList.sortRange(ArrayList.java:1819)
 	at java.base/java.util.ArrayList.sort(ArrayList.java:1810)
 	at tc.oc.pgm.tablist.MatchTabView.renderTeam(MatchTabView.java:80)
 	at tc.oc.pgm.tablist.MatchTabView.render(MatchTabView.java:204)
 	at tc.oc.pgm.util.tablist.TabManager.priorityRender(TabManager.java:126)
 	at tc.oc.pgm.tablist.MatchTabManager$RenderTask.run(MatchTabManager.java:407)
 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:545)
 	at tc.oc.pgm.util.concurrent.TaskExecutorService$Task.run(TaskExecutorService.java:233)
 	at org.bukkit.craftbukkit.v1_8_R3.scheduler.CraftTask.run(CraftTask.java:64)
 	at org.bukkit.craftbukkit.v1_8_R3.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:409)
 	at net.minecraft.server.v1_8_R3.MinecraftServer.B(MinecraftServer.java:926)
 	at net.minecraft.server.v1_8_R3.DedicatedServer.B(DedicatedServer.java:392)
 	at net.minecraft.server.v1_8_R3.MinecraftServer.A(MinecraftServer.java:848)
 	at net.minecraft.server.v1_8_R3.MinecraftServer.run(MinecraftServer.java:742)
 	at java.base/java.lang.Thread.run(Thread.java:1474)
```

General explanation is that `FriendshipFeatureCore` listens for an async pre login event. Then Community dispatches a `NameDecorationChangeEvent` while still off of the main thread. PGM listens for that event in a number of locations that assume this event is only invoked on the main thread. So fix is to post the event launch to the main thread.