### PR TITLE
fix(events): a bunch of small fixes

### DIFF
--- a/core/src/main/java/dev/pgm/community/party/MapPartyCommands.java
+++ b/core/src/main/java/dev/pgm/community/party/MapPartyCommands.java
@@ -61,7 +61,7 @@ public class MapPartyCommands extends CommunityCommand {
     }
   }
 
-  @Command("preset [name]")
+  @Command("preset <name>")
   @Permission(CommunityPermissions.PARTY)
   public void createPreset(
       CommandAudience viewer,

--- a/core/src/main/java/dev/pgm/community/party/MapPartyCommands.java
+++ b/core/src/main/java/dev/pgm/community/party/MapPartyCommands.java
@@ -47,7 +47,7 @@ public class MapPartyCommands extends CommunityCommand {
     }
   }
 
-  @Command("create [type]")
+  @Command("create <type>")
   @Permission(CommunityPermissions.PARTY)
   public void create(
       CommandAudience viewer,

--- a/core/src/main/java/dev/pgm/community/party/feature/MapPartyFeature.java
+++ b/core/src/main/java/dev/pgm/community/party/feature/MapPartyFeature.java
@@ -184,6 +184,7 @@ public class MapPartyFeature extends FeatureBase {
       case REGULAR:
         this.party = new RegularPoolParty(sender, getEventConfig());
         break;
+      case null:
       default:
         return false;
       // Catch unknown party type

--- a/core/src/main/java/dev/pgm/community/party/hosts/MapPartyHosts.java
+++ b/core/src/main/java/dev/pgm/community/party/hosts/MapPartyHosts.java
@@ -67,7 +67,8 @@ public class MapPartyHosts {
 
   public boolean removeSubHost(String name) {
     Entry<UUID, String> cachedEntry = nameCache.entrySet().stream()
-        .filter(e -> e.getValue().equalsIgnoreCase(name))
+        .filter(e ->
+            e.getKey().toString().equalsIgnoreCase(name) || e.getValue().equalsIgnoreCase(name))
         .findAny()
         .orElse(null);
 

--- a/core/src/main/java/dev/pgm/community/party/menu/hosts/HostAddMenu.java
+++ b/core/src/main/java/dev/pgm/community/party/menu/hosts/HostAddMenu.java
@@ -46,7 +46,7 @@ public class HostAddMenu extends PlayerSelectionProvider {
 
   @Override
   public Predicate<Player> relevantPlayerFilter() {
-    return player -> player.hasPermission(CommunityPermissions.STAFF);
+    return player -> player.hasPermission(CommunityPermissions.PARTY);
   }
 
   @Override


### PR DESCRIPTION
This PR addresses a few small issues that have popped up while I was playing around with `/event` locally.

- The menu to add event hosts has been corrected to show people who can host events, instead of all members with the staff permission (some people eligible to host events don't have the staff permission)
- Makes `/event create` and `/event preset` require the type name (or the preset name respectively), preventing NPEs when no arguments are supplied
- Fixed not being able to remove event co-hosts that are online