### PR TITLE
ci: update actions in build pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,35 +13,38 @@ jobs:
       packages: write
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: setup
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           java-version: 21
           distribution: temurin
-      # Configures gradle with caching
+      # Configures gradle with caching. Intentionally pinned to v5.0.2 instead of v6
+      # to benefit from better caching without having to agree to a commercial license,
+      # along with having to trust a 2 MB obfuscated JS blob.
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       # Run "gradlew publish" for origin/dev and "gradlew build" for PRs or elsewhere
       - name: Execute Gradle ${{ (github.repository == 'PGMDev/Community' && github.ref == 'refs/heads/dev') && 'Publish' || 'Build' }}
         run: ./gradlew ${{ (github.repository == 'PGMDev/Community' && github.ref == 'refs/heads/dev') && 'publish' || 'build' }}
         env:
           GITHUB_TOKEN: ${{ (github.repository == 'PGMDev/Community' && github.ref == 'refs/heads/dev') && secrets.GITHUB_TOKEN || '' }}
       - name: artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: Community.jar
           path: build/libs/Community.jar
           if-no-files-found: error
+          archive: false
       - name: release vars
         if: github.repository == 'PGMDev/Community' && github.ref == 'refs/heads/dev'
         run: echo "sha_short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
         id: release_vars
       - name: release
         if: github.repository == 'PGMDev/Community' && github.ref == 'refs/heads/dev'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: dev-${{ steps.release_vars.outputs.sha_short }}
           name: Dev build ${{ steps.release_vars.outputs.sha_short }}


### PR DESCRIPTION
Updates the GitHub actions pipeline to move off of Node.js v20-based actions. Like with https://github.com/PGMDev/PGM/pull/1708:
- The built .jar artifact is no longer zipped
- `actions/setup-gradle` at v5.0.2 was used instead of v6 for better caching without having to agree to a commercial license

On top of the above, full commit SHAs are used instead of version tags. This is a side-effect of me using [pnpm](https://pnpm.io/) to semi-automate the update[^1]; I'm keeping it that way nevertheless as it's considered [a good security practice](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions) to reduce supply chain attack risk.

[^1]: I learnt about pnpm being able to update workflows sometime later after the PGM pull request was merged in, so tagged versions are being used there. Might update it over there as well at a later point.